### PR TITLE
Change from address for inquiry emails

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -22,3 +22,7 @@ MAIL_TO_CENSUS_SUBJECT=Comment from Census 2020 info site
 
 # Email address to send inquiries to
 MAIL_TO_CENSUS_ADDRESS=census.dept@example.com
+
+# Email address to use as the from address for inquiries from the
+# contact form
+MAIL_TO_CENSUS_FROM_ADDRESS=inquiry@example.com

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -17,7 +17,8 @@ module.exports = {
 
     inquiryMessage: {
       subject: process.env.MAIL_TO_CENSUS_SUBJECT,
-      address: process.env.MAIL_TO_CENSUS_ADDRESS
+      address: process.env.MAIL_TO_CENSUS_ADDRESS,
+      fromAddress: process.env.MAIL_TO_CENSUS_FROM_ADDRESS
     }
   },
   db: {

--- a/src/mail/send-message.js
+++ b/src/mail/send-message.js
@@ -76,7 +76,8 @@ module.exports.sendToCensusDept = async ({
   });
 
   const sendResults = await transporter.sendMail({
-    from: email,
+    from: Config.mail.inquiryMessage.fromAddress,
+    replyTo: email,
     to: Config.mail.inquiryMessage.address,
     subject: Config.mail.inquiryMessage.subject,
     text: messageText


### PR DESCRIPTION
Previously, the user's entered email address was being used as the "from" address for emails sent via the contact form. That works okay, but there's a risk that the Census email account it's sent to might put them in the spam folder. If there's a constant, known from address, the Census Department can whitelist that address so that the emails always get through. It would also allow them to set up a filter or rule to apply to all emails from the contact form (with the individual user's email as the from address, they could only do that by matching on the subject line or something, which is much more fragile). The user's email is now set as the reply-to address, so the Census Department will still be able to reply to the requester simply by hitting "Reply".