### PR TITLE
Add questions for FAQ page

### DIFF
--- a/client/components/Contact.js
+++ b/client/components/Contact.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage, injectIntl } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import { toast } from 'react-toastify';
 
 import 'react-toastify/dist/ReactToastify.css';
@@ -17,9 +17,6 @@ import contactFormImageSrc from '../images/contact-form.jpg';
 
 class Contact extends Component {
   static propTypes = {
-    intl: PropTypes.shape({
-      formatMessage: PropTypes.func.isRequired
-    }).isRequired,
     currentLocale: PropTypes.oneOf(supportedLocales)
   }
 
@@ -48,11 +45,13 @@ class Contact extends Component {
 
   notifySubmitSuccess () {
     toast(
-      this.props.intl.formatMessage({
-        id: 'components.Contact.submitSuccessToast',
-        description: 'Message shown to users in a popup when the contact form has been successfully submitted',
-        defaultMessage: 'Your request for information has been submitted'
-      }),
+      (
+        <FormattedMessage
+          id="components.Contact.submitSuccessToast"
+          description="Message shown to users in a popup when the contact form has been successfully submitted"
+          defaultMessage="Your request for information has been submitted"
+        />
+      ),
       {
         type: toast.TYPE.SUCCESS,
         position: toast.POSITION.BOTTOM_CENTER,
@@ -123,45 +122,53 @@ class Contact extends Component {
     const options = [
       {
         value: 'volunteer',
-        label: this.props.intl.formatMessage({
-          key: 'volunteer',
-          id: 'components.Contact.fields.interest.options.volunteer',
-          defaultMessage: 'Volunteer to help',
-          description: "'Volunteer to help' option for the Interest field in the Contact form"
-        }),
+        label: (
+          <FormattedMessage
+            key="volunteer"
+            id="components.Contact.fields.interest.options.volunteer"
+            defaultMessage="Volunteer to help"
+            description="'Volunteer to help' option for the Interest field in the Contact form"
+          />
+        ),
         name: 'volunteer',
         checked: interests.has('volunteer')
       },
       {
         value: 'presentation',
-        label: this.props.intl.formatMessage({
-          key: 'requestPresentation',
-          id: 'components.Contact.fields.interest.options.requestPresentation',
-          defaultMessage: 'Request a presentation',
-          description: "'Request a Presentation' option for the Interest field in the Contact form"
-        }),
+        label: (
+          <FormattedMessage
+            key="requestPresentation"
+            id="components.Contact.fields.interest.options.requestPresentation"
+            defaultMessage="Request a presentation"
+            description="'Request a Presentation' option for the Interest field in the Contact form"
+          />
+        ),
         name: 'presentation',
         checked: interests.has('presentation')
       },
       {
         value: 'information',
-        label: this.props.intl.formatMessage({
-          key: 'information',
-          id: 'components.Contact.fields.interest.options.information',
-          defaultMessage: 'Request more information',
-          description: "'Request more information' option for the Interest field in the Contact form"
-        }),
+        label: (
+          <FormattedMessage
+            key="information"
+            id="components.Contact.fields.interest.options.information"
+            defaultMessage="Request more information"
+            description="'Request more information' option for the Interest field in the Contact form"
+          />
+        ),
         name: 'information',
         checked: interests.has('information')
       },
       {
         value: 'other',
-        label: this.props.intl.formatMessage({
-          key: 'other',
-          id: 'components.Contact.fields.interest.options.other',
-          defaultMessage: 'Other',
-          description: "'Other' option for the Interest field in the Contact form"
-        }),
+        label: (
+          <FormattedMessage
+            key="other"
+            id="components.Contact.fields.interest.options.other"
+            defaultMessage="Other"
+            description="'Other' option for the Interest field in the Contact form"
+          />
+        ),
         name: 'other',
         checked: interests.has('other')
       }
@@ -362,19 +369,17 @@ class Contact extends Component {
   }
 }
 
-const WrappedContact = injectIntl(
-  (props) => (
-    <LocaleContext.Consumer>
-      {
-        ({ currentLocale }) => (
-          <Contact
-            {...props}
-            currentLocale={currentLocale}
-          />
-        )
-      }
-    </LocaleContext.Consumer>
-  )
+const WrappedContact = (props) => (
+  <LocaleContext.Consumer>
+    {
+      ({ currentLocale }) => (
+        <Contact
+          {...props}
+          currentLocale={currentLocale}
+        />
+      )
+    }
+  </LocaleContext.Consumer>
 );
 
 export default WrappedContact;

--- a/client/components/FAQ.js
+++ b/client/components/FAQ.js
@@ -1,218 +1,426 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
 import classnames from 'classnames';
+import { FormattedMarkdownMessage } from './FormattedMarkdownMessage';
 
 import './FAQ.scss';
 
-const GENERAL_INFORMATION_SECTION_KEY = 'generalInformation';
-const SECURITY_SECTION_KEY = 'security';
-const VALUE_SECTION_KEY = 'value';
+const SECTION_KEYS = {
+  BASIC: 'basic',
+  ABOUT: 'about',
+  GETTING_COUNTED: 'gettingCounted',
+  LANGUAGE: 'language',
+  SAFETY: 'safety'
+};
 
 const FAQ_SECTIONS = [
-  GENERAL_INFORMATION_SECTION_KEY,
-  SECURITY_SECTION_KEY,
-  VALUE_SECTION_KEY
+  SECTION_KEYS.BASIC,
+  SECTION_KEYS.ABOUT,
+  SECTION_KEYS.GETTING_COUNTED,
+  SECTION_KEYS.LANGUAGE,
+  SECTION_KEYS.SAFETY
 ];
 
 const HEADERS = {
-  [GENERAL_INFORMATION_SECTION_KEY]: (
-    <FormattedMessage
-      id="components.FAQ.sections.generalInformation.header"
-      defaultMessage="General Information"
+  [SECTION_KEYS.BASIC]: (
+    <FormattedMarkdownMessage
+      id="components.FAQ.sections.basics.header"
+      defaultMessage="Basics"
     />
   ),
-  [SECURITY_SECTION_KEY]: (
-    <FormattedMessage
-      id="components.FAQ.sections.security.header"
-      defaultMessage="Security"
+  [SECTION_KEYS.ABOUT]: (
+    <FormattedMarkdownMessage
+      id="components.FAQ.sections.about.header"
+      defaultMessage="About the Survey"
     />
   ),
-  [VALUE_SECTION_KEY]: (
-    <FormattedMessage
-      id="components.FAQ.sections.value.header"
-      defaultMessage="Value"
+  [SECTION_KEYS.GETTING_COUNTED]: (
+    <FormattedMarkdownMessage
+      id="components.FAQ.sections.gettingCounted.header"
+      defaultMessage="Getting Counted"
+    />
+  ),
+  [SECTION_KEYS.LANGUAGE]: (
+    <FormattedMarkdownMessage
+      id="components.FAQ.sections.language.header"
+      defaultMessage="Language Access"
+    />
+  ),
+  [SECTION_KEYS.SAFETY]: (
+    <FormattedMarkdownMessage
+      id="components.FAQ.sections.safety.header"
+      defaultMessage="Safety and Privacy"
     />
   )
 };
 
 const FAQ_ENTRIES = {
-  [GENERAL_INFORMATION_SECTION_KEY]: [
+  [SECTION_KEYS.BASIC]: [
     {
       question: (
-        <FormattedMessage
-          id="components.FAQ.entries.howCanIComplete.question"
-          defaultMessage="How can I complete the Census?"
+        <FormattedMarkdownMessage
+          id="components.FAQ.entries.whatIsTheCensus.question"
+          defaultMessage="What is the census?"
         />
       ),
       answer: (
-        <FormattedMessage
-          id="components.FAQ.entries.howCanIComplete.answer"
-          defaultMessage="There are four ways you can respond to the census: over the internet, by telephone, by mail (paper questionnaire) or via in-person visit from census workers."
+        <FormattedMarkdownMessage
+          id="components.FAQ.entries.whatIsTheCensus.answer"
+          defaultMessage="The United States Census is a national population count that occurs every ten years. It is mandated by the U.S. Constitution."
         />
       )
     },
     {
       question: (
-        <FormattedMessage
-          id="components.FAQ.entries.typesOfQuestions.question"
-          defaultMessage="What types of questions are on the Census?"
+        <FormattedMarkdownMessage
+          id="components.FAQ.entries.whyHaveCensus.question"
+          defaultMessage="Why do we have a census?"
         />
       ),
       answer: (
-        <FormattedMessage
-          id="components.FAQ.entries.typesOfQuestions.answer"
-          defaultMessage="The 2020 Census will ask basic information about each household, such as the total number of people living at your address, homeownership (own or rent), your phone number, and the names, gender, race/ethnicity of each individual living or staying with you. This information will not be shared with the City or any other local, state or federal agency."
+        <FormattedMarkdownMessage
+          id="components.FAQ.entries.whyHaveCensus.answer"
+          defaultMessage="The data collected from the Census is used to make sure everyone is equally represented in our political system and that government resources are allocated fairly. The Census data determines how many congressional seats a state receives; how much federal funding will be allocated to local communities for public services and infrastructure needs; and provides a picture of the changing demographics of the country."
         />
       )
     },
     {
       question: (
-        <FormattedMessage
-          id="components.FAQ.entries.howLong.question"
-          defaultMessage="How long will it take to complete?"
+        <FormattedMarkdownMessage
+          id="components.FAQ.entries.whoGetsCounted.question"
+          defaultMessage="Who gets counted?"
         />
       ),
       answer: (
-        <FormattedMessage
-          id="components.FAQ.entries.howLong.answer"
-          defaultMessage="The census survey is short and on average takes about 10 minutes or less to complete, depending on the number of people in the household."
+        <FormattedMarkdownMessage
+          id="components.FAQ.entries.whoGetsCounted.answer"
+          defaultMessage="Everyone living in the United States must be counted. Make sure you include everyone living and sleeping in your home on your census survey — regardless of age, gender, relationship to you, or citizenship/immigration status."
         />
       )
     },
     {
       question: (
-        <FormattedMessage
-          id="components.FAQ.entries.otherLanguages.question"
-          defaultMessage="Will the census be available in other languages?"
+        <FormattedMarkdownMessage
+          id="components.FAQ.entries.whenGetInvitation.question"
+          defaultMessage="When should I look for my invitation in the mail?"
         />
       ),
       answer: (
-        <FormattedMessage
-          id="components.FAQ.entries.otherLanguages.answer"
-          defaultMessage="Yes. The online survey is available in 12 languages (Spanish, Chinese, Vietnamese, Korean, Russian, Arabic, Tagalog, Polish, French, Haitian Creole, Portuguese, Japanese); phone assistance will also be available in these languages by calling (####). The paper survey is available in English and Spanish. Call to request a paper survey./n The U.S. Census Bureau will provide other materials such as languages guides, glossaries, etc. in 59 languages. Residents who need assistance or who do not have computer or internet access can visit a City library or community center for assistance."
-        />
-      )
-    },
-    {
-      question: (
-        <FormattedMessage
-          id="components.FAQ.entries.forgotId.question"
-          defaultMessage="I forgot my ID. Can I still take the Census?"
-        />
-      ),
-      answer: (
-        <FormattedMessage
-          id="components.FAQ.entries.forgotId.answer"
-          defaultMessage="Yes. If you did not receive a census ID code or misplaced it, you can still complete the online census survey by using your mailing address. If you don’t want to respond online, you can call Census Questionnaire Assistance at (###) to complete the survey over the phone, or request a paper survey, also using the same unique ID number or providing your home address."
+        <FormattedMarkdownMessage
+          id="components.FAQ.entries.whenGetInvitation.answer"
+          defaultMessage="Starting in March 2020, the U.S. Census Bureau will mail letters to every household in the United States inviting them to respond to the Census survey. Every household should receive a letter requesting that they complete a census form online, by mail, or phone by Census Day on April 1, 2020."
         />
       )
     }
   ],
-  [SECURITY_SECTION_KEY]: [
+  [SECTION_KEYS.ABOUT]: [
     {
       question: (
-        <FormattedMessage
-          id="components.FAQ.entries.willInfoBeShared.question"
-          defaultMessage="Will my census information be shared with the government?"
+        <FormattedMarkdownMessage
+          id="components.FAQ.entries.whatTypesOfQuestions.question"
+          defaultMessage="What types of questions are on the 2020 Census?"
         />
       ),
       answer: (
-        <FormattedMessage
-          id="components.FAQ.entries.willInfoBeShared.answer"
-          defaultMessage="No. Census information is confidential. Individuals’ responses to the 2020 census are safe, secure and protected by federal law. Your answers can only be used to produce statistics; they cannot be used against you in any way. The Bureau combines your responses with information from other households to produce data, and the data will not identify your household or any person in your household. In addition, all Census Bureau employees take an oath of privacy and are sworn for life to protect the confidentiality of the data. The penalty for unlawful disclosure is a fine of up to $250,000, imprisonment of up to 5 years, or both."
+        <FormattedMarkdownMessage
+          id="components.FAQ.entries.whatTypesOfQuestions.answer"
+          defaultMessage={`The Census survey will ask basic information about each household, such as the total number of people living at your address, homeownership (own or rent), your phone number, and the names, gender, race/ethnicity of each individual living or staying with you. This information will not be shared with the City or any other local, state or federal agency. For more information on what you will be asked on the Census go to the URL below.
+            
+{link}`
+          }
+          values={{
+            link: (
+              <a href="https://2020census.gov/en/about-questions.html">
+                https://2020census.gov/en/about-questions.html
+              </a>
+            )
+          }}
         />
       )
     },
     {
       question: (
-        <FormattedMessage
-          id="components.FAQ.entries.howToIdentifyAnOfficial.question"
-          defaultMessage="How do I identify a Census official in person?"
+        <FormattedMarkdownMessage
+          id="components.FAQ.entries.whatIsHouseholdRelationshipQuestion.question"
+          defaultMessage={'What is the "Household Relationship Question"?'}
         />
       ),
       answer: (
-        <FormattedMessage
-          id="components.FAQ.entries.howToIdentifyAnOfficial.answer"
-          defaultMessage="If someone visits your home to collect a response for the 2020 Census, there are steps you can take to verify their identity.First, check to make sure that they have a valid ID badge, with their photograph, a Department of Commerce watermark, and an expiration date. Note that they may be carrying a Census Bureau phone or a laptop, plus a bag with a Census Bureau logo. If you still have questions, call 855-562-2020 and press option 3 to speak with a local Census Bureau representative."
+        <FormattedMarkdownMessage
+          id="components.FAQ.entries.whatIsHouseholdRelationshipQuestion.answer"
+          defaultMessage="For the first time, the 2020 Census offers a way for the person filling out the form to indicate a same-sex relationship with another household member. This change is expected to improve national statistics on same-sex couples."
         />
       )
     },
     {
       question: (
-        <FormattedMessage
+        <FormattedMarkdownMessage
+          id="components.FAQ.entries.whoCountsAsHousehold.question"
+          defaultMessage={'Who counts as a "household?"'}
+        />
+      ),
+      answer: (
+        <FormattedMarkdownMessage
+          id="components.FAQ.entries.whoCountsAsHousehold.answer"
+          defaultMessage={`A household consists of all the people who occupy a housing unit, both related family members and all the unrelated people, if any, such as lodgers, foster children, wards, or employees who share the housing. For more information on who to count on your Census form go to the URL below.
+          
+{link}`
+          }
+          values={{
+            link: (
+              <a href="https://2020census.gov/en/who-to-count.html">
+                https://2020census.gov/en/who-to-count.html
+              </a>
+            )
+          }}
+        />
+      )
+    },
+    {
+      question: (
+        <FormattedMarkdownMessage
+          id="components.FAQ.entries.howLongDoesItTake.question"
+          defaultMessage="How long does it take to complete the census?"
+        />
+      ),
+      answer: (
+        <FormattedMarkdownMessage
+          id="components.FAQ.entries.howLongDoesItTake.answer"
+          defaultMessage="The census survey is short and on average takes about 10 minutes or less to complete, depending on the number of people living/sleeping in your home."
+        />
+      )
+    }
+  ],
+  [SECTION_KEYS.GETTING_COUNTED]: [
+    {
+      question: (
+        <FormattedMarkdownMessage
+          id="components.FAQ.entries.howCanIComplete.question"
+          defaultMessage="How can I complete the census?"
+        />
+      ),
+      answer: (
+        <FormattedMarkdownMessage
+          id="components.FAQ.entries.howCanIComplete.answer"
+          defaultMessage="There are three ways you can fill out the Census survey: online, by telephone, or via mail. Households can answer the questions on the internet or by phone in English and 12 Non-English languages."
+        />
+      )
+    },
+    {
+      question: (
+        <FormattedMarkdownMessage
+          id="components.FAQ.entries.isFirstTimeAvailableOnline.question"
+          defaultMessage="Is this the first time the census survey will be available online?"
+        />
+      ),
+      answer: (
+        <FormattedMarkdownMessage
+          id="components.FAQ.entries.isFirstTimeAvailableOnline.answer"
+          defaultMessage="Yes! The 2020 Census will be the first Census to be almost entirely digital! The survey will be available in English and 12 Non-English languages."
+        />
+      )
+    },
+    {
+      question: (
+        <FormattedMarkdownMessage
+          id="components.FAQ.entries.whenCanFillOut.question"
+          defaultMessage="When can I go online to fill out the census survey?"
+        />
+      ),
+      answer: (
+        <FormattedMarkdownMessage
+          id="components.FAQ.entries.whenCanFillOut.answer"
+          defaultMessage="Beginning in mid-March 2020, households will receive an invitation in the mail to participate in the census by visiting the U.S. Census Bureau’s 2020 Census website to fill out the online survey."
+        />
+      )
+    },
+    {
+      question: (
+        <FormattedMarkdownMessage
+          id="components.FAQ.entries.lostCensusId.question"
+          defaultMessage="I don’t have or lost my census ID. Can I still complete the census?"
+        />
+      ),
+      answer: (
+        <FormattedMarkdownMessage
+          id="components.FAQ.entries.lostCensusId.answer"
+          defaultMessage="Yes. If you did not receive a census ID code or misplaced it, you can still complete the online census survey by using your mailing address. If you don’t want to respond online, you can call Census Questionnaire Assistance at (###) to complete the survey over the phone."
+        />
+      )
+    },
+    {
+      question: (
+        <FormattedMarkdownMessage
+          id="components.FAQ.entries.noAccessToComputer.question"
+          defaultMessage="What if I don’t have access to a computer?"
+        />
+      ),
+      answer: (
+        <FormattedMarkdownMessage
+          id="components.FAQ.entries.noAccessToComputer.answer"
+          defaultMessage="Households that do not have internet access are encouraged to visit a Census Kiosk to get counted in the 2020 Census. These dedicated computer stations will be available at City library branches, community centers and City Hall. In-person assistance will be available at most locations."
+        />
+      )
+    },
+    {
+      question: (
+        <FormattedMarkdownMessage
+          id="components.FAQ.entries.whatHappensIfNoResponse.question"
+          defaultMessage="What happens if I don’t respond to the Census?"
+        />
+      ),
+      answer: (
+        <FormattedMarkdownMessage
+          id="components.FAQ.entries.whatHappensIfNoResponse.answer"
+          defaultMessage="If your household fails to respond online or by telephone, the U.S. Census Bureau will mail several reminders to your household and will ultimately mail you a printed questionnaire—in English and Spanish—for you to return by mail."
+        />
+      )
+    },
+    {
+      question: (
+        <FormattedMarkdownMessage
+          id="components.FAQ.entries.whatHappensIfNoResponseAtAll.question"
+          defaultMessage="What happens if I don’t respond to the census at all?"
+        />
+      ),
+      answer: (
+        <FormattedMarkdownMessage
+          id="components.FAQ.entries.whatHappensIfNoResponseAtAll.answer"
+          defaultMessage="If your household does not respond to the Census online, by phone, or via mail by late April 2020, the U.S. Census Bureau will send a Census worker, known as an enumerator, to your address to help you complete the survey. To avoid a visit from a census worker, complete the census survey on your own."
+        />
+      )
+    },
+    {
+      question: (
+        <FormattedMarkdownMessage
+          id="components.FAQ.entries.whatWillCensusWorkerAsk.question"
+          defaultMessage="What will the Census worker ask me?"
+        />
+      ),
+      answer: (
+        <FormattedMarkdownMessage
+          id="components.FAQ.entries.whatWillCensusWorkerAsk.answer"
+          defaultMessage="The Census worker will ask you all the same survey questions that will appear in the online version of the Census."
+        />
+      )
+    }
+  ],
+  [SECTION_KEYS.LANGUAGE]: [
+    {
+      question: (
+        <FormattedMarkdownMessage
+          id="components.FAQ.entries.otherLanguages.question"
+          defaultMessage="I don’t speak English. Will the Census survey be available in other languages?"
+        />
+      ),
+      answer: (
+        <FormattedMarkdownMessage
+          id="components.FAQ.entries.otherLanguages.answer"
+          defaultMessage="Yes. The online survey is available in English and 12 other languages (Spanish, Chinese, Vietnamese, Korean, Russian, Arabic, Tagalog, Polish, French, Haitian Creole, Portuguese, Japanese); phone assistance will also be available in these languages by calling (####). The paper survey is available in English and Spanish. Print and video language guides will be available in 59 Non-English languages, including American Sign Language, Braille, and large print."
+        />
+      )
+    }
+  ],
+  [SECTION_KEYS.SAFETY]: [
+    {
+      question: (
+        <FormattedMarkdownMessage
+          id="components.FAQ.entries.isCensusSafe.question"
+          defaultMessage="Is the Census safe?"
+        />
+      ),
+      answer: (
+        <FormattedMarkdownMessage
+          id="components.FAQ.entries.isCensusSafe.answer"
+          defaultMessage="Under federal census law, your responses are kept confidential and can only be used by the U.S. Census Bureau to produce statistics."
+        />
+      )
+    },
+    {
+      question: (
+        <FormattedMarkdownMessage
+          id="components.FAQ.entries.canOtherAgenciesAccess.question"
+          defaultMessage="Can another government agency access my census information?"
+        />
+      ),
+      answer: (
+        <FormattedMarkdownMessage
+          id="components.FAQ.entries.canOtherAgenciesAccess.answer"
+          defaultMessage="No. Title 13 of the U.S. Code requires your information to be kept confidential and prevents your responses from being used against you by any government agency--including law enforcement, the Department of Homeland Security, or US Immigration and Customs Enforcement. All Census Bureau employees take an oath of privacy and are sworn for life to protect the confidentiality of the data. The penalty for unlawful disclosure is a fine of up to $250,000, imprisonment of up to 5 years, or both."
+        />
+      )
+    },
+    {
+      question: (
+        <FormattedMarkdownMessage
+          id="components.FAQ.entries.howToIdentifyCensusWorker.question"
+          defaultMessage="How do I identify an official census worker in person?"
+        />
+      ),
+      answer: (
+        <FormattedMarkdownMessage
+          id="components.FAQ.entries.howToIdentifyCensusWorker.answer"
+          defaultMessage={`If someone visits your home to collect a response for the 2020 Census, there are steps you can take to verify their identity:
+              
+  First, check to make sure that they have a valid ID badge, with their photograph, a Department of Commerce watermark, and an expiration date.
+  Note that they may be carrying a Census Bureau phone or a laptop, plus a bag with a Census Bureau logo.
+  If you still have questions, call 855-562-2020 and press option 3 to speak with a local Census Bureau representative.
+  
+  Remember that the U.S. Census Bureau will never ask for:
+  
+  - Your Social Security number.
+  - Your bank account or credit card numbers.
+  - Money or donations.
+  
+  In addition, the Census Bureau will not contact you on behalf of a political party.`
+          }
+        />
+      )
+    },
+    {
+      question: (
+        <FormattedMarkdownMessage
           id="components.FAQ.entries.howToAvoidScams.question"
           defaultMessage="How can I avoid scams online?"
         />
       ),
       answer: (
-        <FormattedMessage
+        <FormattedMarkdownMessage
           id="components.FAQ.entries.howToAvoidScams.answer"
-          defaultMessage="Phishing is the criminal act of trying to get your information by pretending to be an entity that you trust. Phishing emails often direct you to a website that looks real but is fake—and that may be infected with malware.To help protect yourself from phishing and other scams, please remember that the U.S. Census Bureau will never ask for: Your Social Security number. Your bank account or credit card numbers. Money or donations. In addition, the Census Bureau will not contact you on behalf of a political party."
+          defaultMessage={`Phishing is the criminal act of trying to get your information by pretending to be an entity that you trust. Phishing emails often direct you to a website that looks real but is fake—and that may be infected with malware.
+
+To help protect yourself from phishing and other scams, please remember that the U.S. Census Bureau will never ask for:
+
+- Your Social Security number.
+- Your bank account or credit card numbers.
+- Money or donations.
+
+In addition, the Census Bureau will not contact you on behalf of a political party.`
+          }
         />
       )
     },
     {
       question: (
-        <FormattedMessage
+        <FormattedMarkdownMessage
           id="components.FAQ.entries.howToReportFraud.question"
           defaultMessage="How do I report suspected fraud?"
         />
       ),
       answer: (
-        <FormattedMessage
+        <FormattedMarkdownMessage
           id="components.FAQ.entries.howToReportFraud.answer"
-          defaultMessage="If you suspect fraud, call 855-562-2020 and press option 3 to speak with a local Census Bureau representative. If it is determined that the visitor who came to your door does not work for the Census Bureau, contact the Police Department (phone ##)."
-        />
-      )
-    }
-  ],
-  [VALUE_SECTION_KEY]: [
-    {
-      question: (
-        <FormattedMessage
-          id="components.FAQ.entries.doINeedToComplete.question"
-          defaultMessage="Do I need to complete the Census?"
-        />
-      ),
-      answer: (
-        <FormattedMessage
-          id="components.FAQ.entries.doINeedToComplete.answer"
-          defaultMessage="Yes, all people living in the United States must be counted. Historically, young children (ages 0-4), teenagers, senior citizens, renters, immigrants, and the homeless population are undercounted in the census."
-        />
-      )
-    },
-    {
-      question: (
-        <FormattedMessage
-          id="components.FAQ.entries.whyImportant.question"
-          defaultMessage="Why is the census important?"
-        />
-      ),
-      answer: (
-        <FormattedMessage
-          id="components.FAQ.entries.whyImportant.answer"
-          defaultMessage="Yes, all people living in the United States must be counted. Historically, young children (ages 0-4), teenagers, senior citizens, renters, immigrants, and the homeless population are undercounted in the census."
-        />
-      )
-    },
-    {
-      question: (
-        <FormattedMessage
-          id="components.FAQ.entries.homeless.question"
-          defaultMessage="How will the Census count homeless residents?"
-        />
-      ),
-      answer: (
-        <FormattedMessage
-          id="components.FAQ.entries.homeless.answer"
-          defaultMessage="In late March 2020, the Census Bureau will conduct Service-Based Enumeration (SBE). During this time, Census workers will count people without conventional housing or people experiencing homelessness at places where they receive services (e.g., shelters, soup kitchens, regularly scheduled mobile food van locations, etc.) or at pre-identified outdoor locations where people are known to sleep — such as encampments, under bridges, or in parking lots"
+          defaultMessage="If you suspect fraud, call {phoneNumber} and press option 3 to speak with a local Census Bureau representative. If it is determined that the visitor who came to your door does not work for the Census Bureau, contact the Police Department (phone ##)."
+          values={{
+            phoneNumber: (
+              <a href="tel:855-562-2020">855-562-2020</a>
+            )
+          }}
         />
       )
     }
   ]
 };
-
 class Question extends React.Component {
   constructor (props) {
     super(props);
@@ -255,7 +463,7 @@ export default class FAQ extends React.Component {
         <div className="c_faq__page-header"></div>
         <div className="c_faq__body">
           <header className="c_faq__header" >
-            <FormattedMessage
+            <FormattedMarkdownMessage
               id="components.FAQ.header"
               description="FAQ page header text"
               defaultMessage="Frequently Asked Questions"

--- a/client/components/FormattedMarkdownMessage.js
+++ b/client/components/FormattedMarkdownMessage.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import { useIntl } from 'react-intl';
+import PropTypes from 'prop-types';
+import Markdown from 'react-remarkable';
+
+export const FormattedMarkdownMessage = ({ id, description, defaultMessage, values }) => {
+  const intl = useIntl();
+  const markdown = intl.formatMessage(
+    {
+      id,
+      description,
+      defaultMessage
+    },
+    values
+  );
+
+  if (Array.isArray(markdown)) {
+    for (let i = 0; i < markdown.length; i++) {
+      const part = markdown[i];
+      if (React.isValidElement(part) && !part.props.key) {
+        markdown[i] = React.cloneElement(markdown[i], {
+          key: i
+        });
+      }
+    }
+  }
+
+  return (
+    <Markdown>
+      {markdown}
+    </Markdown>
+  );
+};
+
+FormattedMarkdownMessage.propTypes = {
+  id: PropTypes.string.isRequired,
+  description: PropTypes.string,
+  defaultMessage: PropTypes.string,
+  values: PropTypes.object
+};

--- a/i18n/extract-strings.js
+++ b/i18n/extract-strings.js
@@ -56,7 +56,9 @@ for (const file of filesToCheck) {
         [
           'babel-plugin-react-intl',
           {
-            extractFromFormatMessageCall: true
+            additionalComponentNames: [
+              'FormattedMarkdownMessage'
+            ]
           }
         ]
       ]

--- a/i18n/translations/definitions.json
+++ b/i18n/translations/definitions.json
@@ -396,5 +396,233 @@
     "id": "components.SampleCensus.subtitle",
     "description": "Sample Census page subtitle",
     "defaultMessage": "Learn how to answer, how that info is used, and why it's important to answer"
+  },
+  "components.FAQ.sections.basics.header": {
+    "id": "components.FAQ.sections.basics.header",
+    "defaultMessage": "Basics"
+  },
+  "components.FAQ.sections.about.header": {
+    "id": "components.FAQ.sections.about.header",
+    "defaultMessage": "About the Survey"
+  },
+  "components.FAQ.sections.gettingCounted.header": {
+    "id": "components.FAQ.sections.gettingCounted.header",
+    "defaultMessage": "Getting Counted"
+  },
+  "components.FAQ.sections.language.header": {
+    "id": "components.FAQ.sections.language.header",
+    "defaultMessage": "Language Access"
+  },
+  "components.FAQ.sections.safety.header": {
+    "id": "components.FAQ.sections.safety.header",
+    "defaultMessage": "Safety and Privacy"
+  },
+  "components.FAQ.entries.whatIsTheCensus.question": {
+    "id": "components.FAQ.entries.whatIsTheCensus.question",
+    "defaultMessage": "What is the census?"
+  },
+  "components.FAQ.entries.whatIsTheCensus.answer": {
+    "id": "components.FAQ.entries.whatIsTheCensus.answer",
+    "defaultMessage": "The United States Census is a national population count that occurs every ten years. It is mandated by the U.S. Constitution."
+  },
+  "components.FAQ.entries.whyHaveCensus.question": {
+    "id": "components.FAQ.entries.whyHaveCensus.question",
+    "defaultMessage": "Why do we have a census?"
+  },
+  "components.FAQ.entries.whyHaveCensus.answer": {
+    "id": "components.FAQ.entries.whyHaveCensus.answer",
+    "defaultMessage": "The data collected from the Census is used to make sure everyone is equally represented in our political system and that government resources are allocated fairly. The Census data determines how many congressional seats a state receives; how much federal funding will be allocated to local communities for public services and infrastructure needs; and provides a picture of the changing demographics of the country."
+  },
+  "components.FAQ.entries.whoGetsCounted.question": {
+    "id": "components.FAQ.entries.whoGetsCounted.question",
+    "defaultMessage": "Who gets counted?"
+  },
+  "components.FAQ.entries.whoGetsCounted.answer": {
+    "id": "components.FAQ.entries.whoGetsCounted.answer",
+    "defaultMessage": "Everyone living in the United States must be counted. Make sure you include everyone living and sleeping in your home on your census survey — regardless of age, gender, relationship to you, or citizenship/immigration status."
+  },
+  "components.FAQ.entries.whenGetInvitation.question": {
+    "id": "components.FAQ.entries.whenGetInvitation.question",
+    "defaultMessage": "When should I look for my invitation in the mail?"
+  },
+  "components.FAQ.entries.whenGetInvitation.answer": {
+    "id": "components.FAQ.entries.whenGetInvitation.answer",
+    "defaultMessage": "Starting in March 2020, the U.S. Census Bureau will mail letters to every household in the United States inviting them to respond to the Census survey. Every household should receive a letter requesting that they complete a census form online, by mail, or phone by Census Day on April 1, 2020."
+  },
+  "components.FAQ.entries.whatTypesOfQuestions.question": {
+    "id": "components.FAQ.entries.whatTypesOfQuestions.question",
+    "defaultMessage": "What types of questions are on the 2020 Census?"
+  },
+  "components.FAQ.entries.whatIsHouseholdRelationshipQuestion.question": {
+    "id": "components.FAQ.entries.whatIsHouseholdRelationshipQuestion.question",
+    "defaultMessage": "What is the \"Household Relationship Question\"?"
+  },
+  "components.FAQ.entries.whatIsHouseholdRelationshipQuestion.answer": {
+    "id": "components.FAQ.entries.whatIsHouseholdRelationshipQuestion.answer",
+    "defaultMessage": "For the first time, the 2020 Census offers a way for the person filling out the form to indicate a same-sex relationship with another household member. This change is expected to improve national statistics on same-sex couples."
+  },
+  "components.FAQ.entries.whoCountsAsHousehold.question": {
+    "id": "components.FAQ.entries.whoCountsAsHousehold.question",
+    "defaultMessage": "Who counts as a \"household?\""
+  },
+  "components.FAQ.entries.howLongDoesItTake.question": {
+    "id": "components.FAQ.entries.howLongDoesItTake.question",
+    "defaultMessage": "How long does it take to complete the census?"
+  },
+  "components.FAQ.entries.howLongDoesItTake.answer": {
+    "id": "components.FAQ.entries.howLongDoesItTake.answer",
+    "defaultMessage": "The census survey is short and on average takes about 10 minutes or less to complete, depending on the number of people living/sleeping in your home."
+  },
+  "components.FAQ.entries.howCanIComplete.question": {
+    "id": "components.FAQ.entries.howCanIComplete.question",
+    "defaultMessage": "How can I complete the census?"
+  },
+  "components.FAQ.entries.howCanIComplete.answer": {
+    "id": "components.FAQ.entries.howCanIComplete.answer",
+    "defaultMessage": "There are three ways you can fill out the Census survey: online, by telephone, or via mail. Households can answer the questions on the internet or by phone in English and 12 Non-English languages."
+  },
+  "components.FAQ.entries.isFirstTimeAvailableOnline.question": {
+    "id": "components.FAQ.entries.isFirstTimeAvailableOnline.question",
+    "defaultMessage": "Is this the first time the census survey will be available online?"
+  },
+  "components.FAQ.entries.isFirstTimeAvailableOnline.answer": {
+    "id": "components.FAQ.entries.isFirstTimeAvailableOnline.answer",
+    "defaultMessage": "Yes! The 2020 Census will be the first Census to be almost entirely digital! The survey will be available in English and 12 Non-English languages."
+  },
+  "components.FAQ.entries.whenCanFillOut.question": {
+    "id": "components.FAQ.entries.whenCanFillOut.question",
+    "defaultMessage": "When can I go online to fill out the census survey?"
+  },
+  "components.FAQ.entries.whenCanFillOut.answer": {
+    "id": "components.FAQ.entries.whenCanFillOut.answer",
+    "defaultMessage": "Beginning in mid-March 2020, households will receive an invitation in the mail to participate in the census by visiting the U.S. Census Bureau’s 2020 Census website to fill out the online survey."
+  },
+  "components.FAQ.entries.lostCensusId.question": {
+    "id": "components.FAQ.entries.lostCensusId.question",
+    "defaultMessage": "I don’t have or lost my census ID. Can I still complete the census?"
+  },
+  "components.FAQ.entries.lostCensusId.answer": {
+    "id": "components.FAQ.entries.lostCensusId.answer",
+    "defaultMessage": "Yes. If you did not receive a census ID code or misplaced it, you can still complete the online census survey by using your mailing address. If you don’t want to respond online, you can call Census Questionnaire Assistance at (###) to complete the survey over the phone."
+  },
+  "components.FAQ.entries.noAccessToComputer.question": {
+    "id": "components.FAQ.entries.noAccessToComputer.question",
+    "defaultMessage": "What if I don’t have access to a computer?"
+  },
+  "components.FAQ.entries.noAccessToComputer.answer": {
+    "id": "components.FAQ.entries.noAccessToComputer.answer",
+    "defaultMessage": "Households that do not have internet access are encouraged to visit a Census Kiosk to get counted in the 2020 Census. These dedicated computer stations will be available at City library branches, community centers and City Hall. In-person assistance will be available at most locations."
+  },
+  "components.FAQ.entries.whatHappensIfNoResponse.question": {
+    "id": "components.FAQ.entries.whatHappensIfNoResponse.question",
+    "defaultMessage": "What happens if I don’t respond to the Census?"
+  },
+  "components.FAQ.entries.whatHappensIfNoResponse.answer": {
+    "id": "components.FAQ.entries.whatHappensIfNoResponse.answer",
+    "defaultMessage": "If your household fails to respond online or by telephone, the U.S. Census Bureau will mail several reminders to your household and will ultimately mail you a printed questionnaire—in English and Spanish—for you to return by mail."
+  },
+  "components.FAQ.entries.whatHappensIfNoResponseAtAll.question": {
+    "id": "components.FAQ.entries.whatHappensIfNoResponseAtAll.question",
+    "defaultMessage": "What happens if I don’t respond to the census at all?"
+  },
+  "components.FAQ.entries.whatHappensIfNoResponseAtAll.answer": {
+    "id": "components.FAQ.entries.whatHappensIfNoResponseAtAll.answer",
+    "defaultMessage": "If your household does not respond to the Census online, by phone, or via mail by late April 2020, the U.S. Census Bureau will send a Census worker, known as an enumerator, to your address to help you complete the survey. To avoid a visit from a census worker, complete the census survey on your own."
+  },
+  "components.FAQ.entries.whatWillCensusWorkerAsk.question": {
+    "id": "components.FAQ.entries.whatWillCensusWorkerAsk.question",
+    "defaultMessage": "What will the Census worker ask me?"
+  },
+  "components.FAQ.entries.whatWillCensusWorkerAsk.answer": {
+    "id": "components.FAQ.entries.whatWillCensusWorkerAsk.answer",
+    "defaultMessage": "The Census worker will ask you all the same survey questions that will appear in the online version of the Census."
+  },
+  "components.FAQ.entries.otherLanguages.question": {
+    "id": "components.FAQ.entries.otherLanguages.question",
+    "defaultMessage": "I don’t speak English. Will the Census survey be available in other languages?"
+  },
+  "components.FAQ.entries.otherLanguages.answer": {
+    "id": "components.FAQ.entries.otherLanguages.answer",
+    "defaultMessage": "Yes. The online survey is available in English and 12 other languages (Spanish, Chinese, Vietnamese, Korean, Russian, Arabic, Tagalog, Polish, French, Haitian Creole, Portuguese, Japanese); phone assistance will also be available in these languages by calling (####). The paper survey is available in English and Spanish. Print and video language guides will be available in 59 Non-English languages, including American Sign Language, Braille, and large print."
+  },
+  "components.FAQ.entries.isCensusSafe.question": {
+    "id": "components.FAQ.entries.isCensusSafe.question",
+    "defaultMessage": "Is the Census safe?"
+  },
+  "components.FAQ.entries.isCensusSafe.answer": {
+    "id": "components.FAQ.entries.isCensusSafe.answer",
+    "defaultMessage": "Under federal census law, your responses are kept confidential and can only be used by the U.S. Census Bureau to produce statistics."
+  },
+  "components.FAQ.entries.canOtherAgenciesAccess.question": {
+    "id": "components.FAQ.entries.canOtherAgenciesAccess.question",
+    "defaultMessage": "Can another government agency access my census information?"
+  },
+  "components.FAQ.entries.canOtherAgenciesAccess.answer": {
+    "id": "components.FAQ.entries.canOtherAgenciesAccess.answer",
+    "defaultMessage": "No. Title 13 of the U.S. Code requires your information to be kept confidential and prevents your responses from being used against you by any government agency--including law enforcement, the Department of Homeland Security, or US Immigration and Customs Enforcement. All Census Bureau employees take an oath of privacy and are sworn for life to protect the confidentiality of the data. The penalty for unlawful disclosure is a fine of up to $250,000, imprisonment of up to 5 years, or both."
+  },
+  "components.FAQ.entries.howToIdentifyCensusWorker.question": {
+    "id": "components.FAQ.entries.howToIdentifyCensusWorker.question",
+    "defaultMessage": "How do I identify an official census worker in person?"
+  },
+  "components.FAQ.entries.howToAvoidScams.question": {
+    "id": "components.FAQ.entries.howToAvoidScams.question",
+    "defaultMessage": "How can I avoid scams online?"
+  },
+  "components.FAQ.entries.howToReportFraud.question": {
+    "id": "components.FAQ.entries.howToReportFraud.question",
+    "defaultMessage": "How do I report suspected fraud?"
+  },
+  "components.FAQ.entries.howToReportFraud.answer": {
+    "id": "components.FAQ.entries.howToReportFraud.answer",
+    "defaultMessage": "If you suspect fraud, call {phoneNumber} and press option 3 to speak with a local Census Bureau representative. If it is determined that the visitor who came to your door does not work for the Census Bureau, contact the Police Department (phone ##)."
+  },
+  "email.messages.confirmation.greeting": {
+    "id": "email.messages.confirmation.greeting",
+    "defaultMessage": "Hi {name}"
+  },
+  "email.messages.confirmation.thankYou": {
+    "id": "email.messages.confirmation.thankYou",
+    "defaultMessage": "Thank you for your interest in the 2020 Census effort in San Jose."
+  },
+  "email.messages.confirmation.usersMessageIntro": {
+    "id": "email.messages.confirmation.usersMessageIntro",
+    "defaultMessage": "The following message was sent by you to the City of San Jose Census Office:"
+  },
+  "email.messages.confirmation.interestsHeader": {
+    "id": "email.messages.confirmation.interestsHeader",
+    "defaultMessage": "I have an interest in:"
+  },
+  "email.messages.confirmation.commentsHeader": {
+    "id": "email.messages.confirmation.commentsHeader",
+    "defaultMessage": "Additional comments:"
+  },
+  "email.messages.confirmation.conclusion": {
+    "id": "email.messages.confirmation.conclusion",
+    "defaultMessage": "Thank you again for your interest. Someone will respond back to you within two business days."
+  },
+  "email.messages.confirmation.signature": {
+    "id": "email.messages.confirmation.signature",
+    "defaultMessage": "City of San Jose 2020 Census Office"
+  },
+  "mail.messages.confirmation.subject": {
+    "id": "mail.messages.confirmation.subject",
+    "defaultMessage": "Thank you for contacting the San Jose Census Department"
+  },
+  "components.FAQ.entries.whatTypesOfQuestions.answer": {
+    "id": "components.FAQ.entries.whatTypesOfQuestions.answer",
+    "defaultMessage": "The Census survey will ask basic information about each household, such as the total number of people living at your address, homeownership (own or rent), your phone number, and the names, gender, race/ethnicity of each individual living or staying with you. This information will not be shared with the City or any other local, state or federal agency. For more information on what you will be asked on the Census go to the URL below.\n            \n{link}"
+  },
+  "components.FAQ.entries.whoCountsAsHousehold.answer": {
+    "id": "components.FAQ.entries.whoCountsAsHousehold.answer",
+    "defaultMessage": "A household consists of all the people who occupy a housing unit, both related family members and all the unrelated people, if any, such as lodgers, foster children, wards, or employees who share the housing. For more information on who to count on your Census form go to the URL below.\n          \n{link}"
+  },
+  "components.FAQ.entries.howToIdentifyCensusWorker.answer": {
+    "id": "components.FAQ.entries.howToIdentifyCensusWorker.answer",
+    "defaultMessage": "If someone visits your home to collect a response for the 2020 Census, there are steps you can take to verify their identity:\n              \n  First, check to make sure that they have a valid ID badge, with their photograph, a Department of Commerce watermark, and an expiration date.\n  Note that they may be carrying a Census Bureau phone or a laptop, plus a bag with a Census Bureau logo.\n  If you still have questions, call 855-562-2020 and press option 3 to speak with a local Census Bureau representative.\n  \n  Remember that the U.S. Census Bureau will never ask for:\n  \n  - Your Social Security number.\n  - Your bank account or credit card numbers.\n  - Money or donations.\n  \n  In addition, the Census Bureau will not contact you on behalf of a political party."
+  },
+  "components.FAQ.entries.howToAvoidScams.answer": {
+    "id": "components.FAQ.entries.howToAvoidScams.answer",
+    "defaultMessage": "Phishing is the criminal act of trying to get your information by pretending to be an entity that you trust. Phishing emails often direct you to a website that looks real but is fake—and that may be infected with malware.\n\nTo help protect yourself from phishing and other scams, please remember that the U.S. Census Bureau will never ask for:\n\n- Your Social Security number.\n- Your bank account or credit card numbers.\n- Money or donations.\n\nIn addition, the Census Bureau will not contact you on behalf of a political party."
   }
 }

--- a/i18n/translations/translations.en.json
+++ b/i18n/translations/translations.en.json
@@ -366,5 +366,233 @@
   "components.SampleCensus.subtitle": {
     "english": "Learn how to answer, how that info is used, and why it's important to answer",
     "translation": "Learn how to answer, how that info is used, and why it's important to answer"
+  },
+  "components.FAQ.sections.basics.header": {
+    "english": "Basics",
+    "translation": "Basics"
+  },
+  "components.FAQ.sections.about.header": {
+    "english": "About the Survey",
+    "translation": "About the Survey"
+  },
+  "components.FAQ.sections.gettingCounted.header": {
+    "english": "Getting Counted",
+    "translation": "Getting Counted"
+  },
+  "components.FAQ.sections.language.header": {
+    "english": "Language Access",
+    "translation": "Language Access"
+  },
+  "components.FAQ.sections.safety.header": {
+    "english": "Safety and Privacy",
+    "translation": "Safety and Privacy"
+  },
+  "components.FAQ.entries.whatIsTheCensus.question": {
+    "english": "What is the census?",
+    "translation": "What is the census?"
+  },
+  "components.FAQ.entries.whatIsTheCensus.answer": {
+    "english": "The United States Census is a national population count that occurs every ten years. It is mandated by the U.S. Constitution.",
+    "translation": "The United States Census is a national population count that occurs every ten years. It is mandated by the U.S. Constitution."
+  },
+  "components.FAQ.entries.whyHaveCensus.question": {
+    "english": "Why do we have a census?",
+    "translation": "Why do we have a census?"
+  },
+  "components.FAQ.entries.whyHaveCensus.answer": {
+    "english": "The data collected from the Census is used to make sure everyone is equally represented in our political system and that government resources are allocated fairly. The Census data determines how many congressional seats a state receives; how much federal funding will be allocated to local communities for public services and infrastructure needs; and provides a picture of the changing demographics of the country.",
+    "translation": "The data collected from the Census is used to make sure everyone is equally represented in our political system and that government resources are allocated fairly. The Census data determines how many congressional seats a state receives; how much federal funding will be allocated to local communities for public services and infrastructure needs; and provides a picture of the changing demographics of the country."
+  },
+  "components.FAQ.entries.whoGetsCounted.question": {
+    "english": "Who gets counted?",
+    "translation": "Who gets counted?"
+  },
+  "components.FAQ.entries.whoGetsCounted.answer": {
+    "english": "Everyone living in the United States must be counted. Make sure you include everyone living and sleeping in your home on your census survey — regardless of age, gender, relationship to you, or citizenship/immigration status.",
+    "translation": "Everyone living in the United States must be counted. Make sure you include everyone living and sleeping in your home on your census survey — regardless of age, gender, relationship to you, or citizenship/immigration status."
+  },
+  "components.FAQ.entries.whenGetInvitation.question": {
+    "english": "When should I look for my invitation in the mail?",
+    "translation": "When should I look for my invitation in the mail?"
+  },
+  "components.FAQ.entries.whenGetInvitation.answer": {
+    "english": "Starting in March 2020, the U.S. Census Bureau will mail letters to every household in the United States inviting them to respond to the Census survey. Every household should receive a letter requesting that they complete a census form online, by mail, or phone by Census Day on April 1, 2020.",
+    "translation": "Starting in March 2020, the U.S. Census Bureau will mail letters to every household in the United States inviting them to respond to the Census survey. Every household should receive a letter requesting that they complete a census form online, by mail, or phone by Census Day on April 1, 2020."
+  },
+  "components.FAQ.entries.whatTypesOfQuestions.question": {
+    "english": "What types of questions are on the 2020 Census?",
+    "translation": "What types of questions are on the 2020 Census?"
+  },
+  "components.FAQ.entries.whatIsHouseholdRelationshipQuestion.question": {
+    "english": "What is the \"Household Relationship Question\"?",
+    "translation": "What is the \"Household Relationship Question\"?"
+  },
+  "components.FAQ.entries.whatIsHouseholdRelationshipQuestion.answer": {
+    "english": "For the first time, the 2020 Census offers a way for the person filling out the form to indicate a same-sex relationship with another household member. This change is expected to improve national statistics on same-sex couples.",
+    "translation": "For the first time, the 2020 Census offers a way for the person filling out the form to indicate a same-sex relationship with another household member. This change is expected to improve national statistics on same-sex couples."
+  },
+  "components.FAQ.entries.whoCountsAsHousehold.question": {
+    "english": "Who counts as a \"household?\"",
+    "translation": "Who counts as a \"household?\""
+  },
+  "components.FAQ.entries.howLongDoesItTake.question": {
+    "english": "How long does it take to complete the census?",
+    "translation": "How long does it take to complete the census?"
+  },
+  "components.FAQ.entries.howLongDoesItTake.answer": {
+    "english": "The census survey is short and on average takes about 10 minutes or less to complete, depending on the number of people living/sleeping in your home.",
+    "translation": "The census survey is short and on average takes about 10 minutes or less to complete, depending on the number of people living/sleeping in your home."
+  },
+  "components.FAQ.entries.howCanIComplete.question": {
+    "english": "How can I complete the census?",
+    "translation": "How can I complete the census?"
+  },
+  "components.FAQ.entries.howCanIComplete.answer": {
+    "english": "There are three ways you can fill out the Census survey: online, by telephone, or via mail. Households can answer the questions on the internet or by phone in English and 12 Non-English languages.",
+    "translation": "There are three ways you can fill out the Census survey: online, by telephone, or via mail. Households can answer the questions on the internet or by phone in English and 12 Non-English languages."
+  },
+  "components.FAQ.entries.isFirstTimeAvailableOnline.question": {
+    "english": "Is this the first time the census survey will be available online?",
+    "translation": "Is this the first time the census survey will be available online?"
+  },
+  "components.FAQ.entries.isFirstTimeAvailableOnline.answer": {
+    "english": "Yes! The 2020 Census will be the first Census to be almost entirely digital! The survey will be available in English and 12 Non-English languages.",
+    "translation": "Yes! The 2020 Census will be the first Census to be almost entirely digital! The survey will be available in English and 12 Non-English languages."
+  },
+  "components.FAQ.entries.whenCanFillOut.question": {
+    "english": "When can I go online to fill out the census survey?",
+    "translation": "When can I go online to fill out the census survey?"
+  },
+  "components.FAQ.entries.whenCanFillOut.answer": {
+    "english": "Beginning in mid-March 2020, households will receive an invitation in the mail to participate in the census by visiting the U.S. Census Bureau’s 2020 Census website to fill out the online survey.",
+    "translation": "Beginning in mid-March 2020, households will receive an invitation in the mail to participate in the census by visiting the U.S. Census Bureau’s 2020 Census website to fill out the online survey."
+  },
+  "components.FAQ.entries.lostCensusId.question": {
+    "english": "I don’t have or lost my census ID. Can I still complete the census?",
+    "translation": "I don’t have or lost my census ID. Can I still complete the census?"
+  },
+  "components.FAQ.entries.lostCensusId.answer": {
+    "english": "Yes. If you did not receive a census ID code or misplaced it, you can still complete the online census survey by using your mailing address. If you don’t want to respond online, you can call Census Questionnaire Assistance at (###) to complete the survey over the phone.",
+    "translation": "Yes. If you did not receive a census ID code or misplaced it, you can still complete the online census survey by using your mailing address. If you don’t want to respond online, you can call Census Questionnaire Assistance at (###) to complete the survey over the phone."
+  },
+  "components.FAQ.entries.noAccessToComputer.question": {
+    "english": "What if I don’t have access to a computer?",
+    "translation": "What if I don’t have access to a computer?"
+  },
+  "components.FAQ.entries.noAccessToComputer.answer": {
+    "english": "Households that do not have internet access are encouraged to visit a Census Kiosk to get counted in the 2020 Census. These dedicated computer stations will be available at City library branches, community centers and City Hall. In-person assistance will be available at most locations.",
+    "translation": "Households that do not have internet access are encouraged to visit a Census Kiosk to get counted in the 2020 Census. These dedicated computer stations will be available at City library branches, community centers and City Hall. In-person assistance will be available at most locations."
+  },
+  "components.FAQ.entries.whatHappensIfNoResponse.question": {
+    "english": "What happens if I don’t respond to the Census?",
+    "translation": "What happens if I don’t respond to the Census?"
+  },
+  "components.FAQ.entries.whatHappensIfNoResponse.answer": {
+    "english": "If your household fails to respond online or by telephone, the U.S. Census Bureau will mail several reminders to your household and will ultimately mail you a printed questionnaire—in English and Spanish—for you to return by mail.",
+    "translation": "If your household fails to respond online or by telephone, the U.S. Census Bureau will mail several reminders to your household and will ultimately mail you a printed questionnaire—in English and Spanish—for you to return by mail."
+  },
+  "components.FAQ.entries.whatHappensIfNoResponseAtAll.question": {
+    "english": "What happens if I don’t respond to the census at all?",
+    "translation": "What happens if I don’t respond to the census at all?"
+  },
+  "components.FAQ.entries.whatHappensIfNoResponseAtAll.answer": {
+    "english": "If your household does not respond to the Census online, by phone, or via mail by late April 2020, the U.S. Census Bureau will send a Census worker, known as an enumerator, to your address to help you complete the survey. To avoid a visit from a census worker, complete the census survey on your own.",
+    "translation": "If your household does not respond to the Census online, by phone, or via mail by late April 2020, the U.S. Census Bureau will send a Census worker, known as an enumerator, to your address to help you complete the survey. To avoid a visit from a census worker, complete the census survey on your own."
+  },
+  "components.FAQ.entries.whatWillCensusWorkerAsk.question": {
+    "english": "What will the Census worker ask me?",
+    "translation": "What will the Census worker ask me?"
+  },
+  "components.FAQ.entries.whatWillCensusWorkerAsk.answer": {
+    "english": "The Census worker will ask you all the same survey questions that will appear in the online version of the Census.",
+    "translation": "The Census worker will ask you all the same survey questions that will appear in the online version of the Census."
+  },
+  "components.FAQ.entries.otherLanguages.question": {
+    "english": "I don’t speak English. Will the Census survey be available in other languages?",
+    "translation": "I don’t speak English. Will the Census survey be available in other languages?"
+  },
+  "components.FAQ.entries.otherLanguages.answer": {
+    "english": "Yes. The online survey is available in English and 12 other languages (Spanish, Chinese, Vietnamese, Korean, Russian, Arabic, Tagalog, Polish, French, Haitian Creole, Portuguese, Japanese); phone assistance will also be available in these languages by calling (####). The paper survey is available in English and Spanish. Print and video language guides will be available in 59 Non-English languages, including American Sign Language, Braille, and large print.",
+    "translation": "Yes. The online survey is available in English and 12 other languages (Spanish, Chinese, Vietnamese, Korean, Russian, Arabic, Tagalog, Polish, French, Haitian Creole, Portuguese, Japanese); phone assistance will also be available in these languages by calling (####). The paper survey is available in English and Spanish. Print and video language guides will be available in 59 Non-English languages, including American Sign Language, Braille, and large print."
+  },
+  "components.FAQ.entries.isCensusSafe.question": {
+    "english": "Is the Census safe?",
+    "translation": "Is the Census safe?"
+  },
+  "components.FAQ.entries.isCensusSafe.answer": {
+    "english": "Under federal census law, your responses are kept confidential and can only be used by the U.S. Census Bureau to produce statistics.",
+    "translation": "Under federal census law, your responses are kept confidential and can only be used by the U.S. Census Bureau to produce statistics."
+  },
+  "components.FAQ.entries.canOtherAgenciesAccess.question": {
+    "english": "Can another government agency access my census information?",
+    "translation": "Can another government agency access my census information?"
+  },
+  "components.FAQ.entries.canOtherAgenciesAccess.answer": {
+    "english": "No. Title 13 of the U.S. Code requires your information to be kept confidential and prevents your responses from being used against you by any government agency--including law enforcement, the Department of Homeland Security, or US Immigration and Customs Enforcement. All Census Bureau employees take an oath of privacy and are sworn for life to protect the confidentiality of the data. The penalty for unlawful disclosure is a fine of up to $250,000, imprisonment of up to 5 years, or both.",
+    "translation": "No. Title 13 of the U.S. Code requires your information to be kept confidential and prevents your responses from being used against you by any government agency--including law enforcement, the Department of Homeland Security, or US Immigration and Customs Enforcement. All Census Bureau employees take an oath of privacy and are sworn for life to protect the confidentiality of the data. The penalty for unlawful disclosure is a fine of up to $250,000, imprisonment of up to 5 years, or both."
+  },
+  "components.FAQ.entries.howToIdentifyCensusWorker.question": {
+    "english": "How do I identify an official census worker in person?",
+    "translation": "How do I identify an official census worker in person?"
+  },
+  "components.FAQ.entries.howToAvoidScams.question": {
+    "english": "How can I avoid scams online?",
+    "translation": "How can I avoid scams online?"
+  },
+  "components.FAQ.entries.howToReportFraud.question": {
+    "english": "How do I report suspected fraud?",
+    "translation": "How do I report suspected fraud?"
+  },
+  "components.FAQ.entries.howToReportFraud.answer": {
+    "english": "If you suspect fraud, call {phoneNumber} and press option 3 to speak with a local Census Bureau representative. If it is determined that the visitor who came to your door does not work for the Census Bureau, contact the Police Department (phone ##).",
+    "translation": "If you suspect fraud, call {phoneNumber} and press option 3 to speak with a local Census Bureau representative. If it is determined that the visitor who came to your door does not work for the Census Bureau, contact the Police Department (phone ##)."
+  },
+  "email.messages.confirmation.greeting": {
+    "english": "Hi {name}",
+    "translation": "Hi {name}"
+  },
+  "email.messages.confirmation.thankYou": {
+    "english": "Thank you for your interest in the 2020 Census effort in San Jose.",
+    "translation": "Thank you for your interest in the 2020 Census effort in San Jose."
+  },
+  "email.messages.confirmation.usersMessageIntro": {
+    "english": "The following message was sent by you to the City of San Jose Census Office:",
+    "translation": "The following message was sent by you to the City of San Jose Census Office:"
+  },
+  "email.messages.confirmation.interestsHeader": {
+    "english": "I have an interest in:",
+    "translation": "I have an interest in:"
+  },
+  "email.messages.confirmation.commentsHeader": {
+    "english": "Additional comments:",
+    "translation": "Additional comments:"
+  },
+  "email.messages.confirmation.conclusion": {
+    "english": "Thank you again for your interest. Someone will respond back to you within two business days.",
+    "translation": "Thank you again for your interest. Someone will respond back to you within two business days."
+  },
+  "email.messages.confirmation.signature": {
+    "english": "City of San Jose 2020 Census Office",
+    "translation": "City of San Jose 2020 Census Office"
+  },
+  "mail.messages.confirmation.subject": {
+    "english": "Thank you for contacting the San Jose Census Department",
+    "translation": "Thank you for contacting the San Jose Census Department"
+  },
+  "components.FAQ.entries.whatTypesOfQuestions.answer": {
+    "english": "The Census survey will ask basic information about each household, such as the total number of people living at your address, homeownership (own or rent), your phone number, and the names, gender, race/ethnicity of each individual living or staying with you. This information will not be shared with the City or any other local, state or federal agency. For more information on what you will be asked on the Census go to the URL below.\n            \n{link}",
+    "translation": "The Census survey will ask basic information about each household, such as the total number of people living at your address, homeownership (own or rent), your phone number, and the names, gender, race/ethnicity of each individual living or staying with you. This information will not be shared with the City or any other local, state or federal agency. For more information on what you will be asked on the Census go to the URL below.\n            \n{link}"
+  },
+  "components.FAQ.entries.whoCountsAsHousehold.answer": {
+    "english": "A household consists of all the people who occupy a housing unit, both related family members and all the unrelated people, if any, such as lodgers, foster children, wards, or employees who share the housing. For more information on who to count on your Census form go to the URL below.\n          \n{link}",
+    "translation": "A household consists of all the people who occupy a housing unit, both related family members and all the unrelated people, if any, such as lodgers, foster children, wards, or employees who share the housing. For more information on who to count on your Census form go to the URL below.\n          \n{link}"
+  },
+  "components.FAQ.entries.howToIdentifyCensusWorker.answer": {
+    "english": "If someone visits your home to collect a response for the 2020 Census, there are steps you can take to verify their identity:\n              \n  First, check to make sure that they have a valid ID badge, with their photograph, a Department of Commerce watermark, and an expiration date.\n  Note that they may be carrying a Census Bureau phone or a laptop, plus a bag with a Census Bureau logo.\n  If you still have questions, call 855-562-2020 and press option 3 to speak with a local Census Bureau representative.\n  \n  Remember that the U.S. Census Bureau will never ask for:\n  \n  - Your Social Security number.\n  - Your bank account or credit card numbers.\n  - Money or donations.\n  \n  In addition, the Census Bureau will not contact you on behalf of a political party.",
+    "translation": "If someone visits your home to collect a response for the 2020 Census, there are steps you can take to verify their identity:\n              \n  First, check to make sure that they have a valid ID badge, with their photograph, a Department of Commerce watermark, and an expiration date.\n  Note that they may be carrying a Census Bureau phone or a laptop, plus a bag with a Census Bureau logo.\n  If you still have questions, call 855-562-2020 and press option 3 to speak with a local Census Bureau representative.\n  \n  Remember that the U.S. Census Bureau will never ask for:\n  \n  - Your Social Security number.\n  - Your bank account or credit card numbers.\n  - Money or donations.\n  \n  In addition, the Census Bureau will not contact you on behalf of a political party."
+  },
+  "components.FAQ.entries.howToAvoidScams.answer": {
+    "english": "Phishing is the criminal act of trying to get your information by pretending to be an entity that you trust. Phishing emails often direct you to a website that looks real but is fake—and that may be infected with malware.\n\nTo help protect yourself from phishing and other scams, please remember that the U.S. Census Bureau will never ask for:\n\n- Your Social Security number.\n- Your bank account or credit card numbers.\n- Money or donations.\n\nIn addition, the Census Bureau will not contact you on behalf of a political party.",
+    "translation": "Phishing is the criminal act of trying to get your information by pretending to be an entity that you trust. Phishing emails often direct you to a website that looks real but is fake—and that may be infected with malware.\n\nTo help protect yourself from phishing and other scams, please remember that the U.S. Census Bureau will never ask for:\n\n- Your Social Security number.\n- Your bank account or credit card numbers.\n- Money or donations.\n\nIn addition, the Census Bureau will not contact you on behalf of a political party."
   }
 }

--- a/i18n/translations/translations.es.json
+++ b/i18n/translations/translations.es.json
@@ -366,5 +366,233 @@
   "components.SampleCensus.subtitle": {
     "english": "Learn how to answer, how that info is used, and why it's important to answer",
     "translation": "Aprenda cómo responder, cómo se usa esa información y por qué es importante responder"
+  },
+  "components.FAQ.sections.basics.header": {
+    "english": "Basics",
+    "translation": "Lo esencial"
+  },
+  "components.FAQ.sections.about.header": {
+    "english": "About the Survey",
+    "translation": "Sobre la encuesta"
+  },
+  "components.FAQ.sections.gettingCounted.header": {
+    "english": "Getting Counted",
+    "translation": "Ser contado"
+  },
+  "components.FAQ.sections.language.header": {
+    "english": "Language Access",
+    "translation": "Acceso al idioma"
+  },
+  "components.FAQ.sections.safety.header": {
+    "english": "Safety and Privacy",
+    "translation": "Seguridad y privacidad"
+  },
+  "components.FAQ.entries.whatIsTheCensus.question": {
+    "english": "What is the census?",
+    "translation": "¿Qué es el censo?"
+  },
+  "components.FAQ.entries.whatIsTheCensus.answer": {
+    "english": "The United States Census is a national population count that occurs every ten years. It is mandated by the U.S. Constitution.",
+    "translation": "El censo de los Estados Unidos es un recuento de población nacional que se produce cada diez años. Es obligatorio por la Constitución de los Estados Unidos."
+  },
+  "components.FAQ.entries.whyHaveCensus.question": {
+    "english": "Why do we have a census?",
+    "translation": "¿Por qué tenemos un censo?"
+  },
+  "components.FAQ.entries.whyHaveCensus.answer": {
+    "english": "The data collected from the Census is used to make sure everyone is equally represented in our political system and that government resources are allocated fairly. The Census data determines how many congressional seats a state receives; how much federal funding will be allocated to local communities for public services and infrastructure needs; and provides a picture of the changing demographics of the country.",
+    "translation": "Los datos recopilados del Censo se utilizan para garantizar que todos estén igualmente representados en nuestro sistema político y que los recursos del gobierno se asignen de manera justa. Los datos del censo determinan cuántos escaños del Congreso recibe un estado; cuánto financiamiento federal se asignará a las comunidades locales para servicios públicos y necesidades de infraestructura; y proporciona una imagen de los cambios demográficos del país."
+  },
+  "components.FAQ.entries.whoGetsCounted.question": {
+    "english": "Who gets counted?",
+    "translation": "¿Quién se cuenta?"
+  },
+  "components.FAQ.entries.whoGetsCounted.answer": {
+    "english": "Everyone living in the United States must be counted. Make sure you include everyone living and sleeping in your home on your census survey — regardless of age, gender, relationship to you, or citizenship/immigration status.",
+    "translation": "Todos los que viven en los Estados Unidos deben ser contados. Asegúrese de incluir a todos los que viven y duermen en su hogar en su encuesta censal, independientemente de su edad, sexo, relación con usted o estado de ciudadanía / inmigración."
+  },
+  "components.FAQ.entries.whenGetInvitation.question": {
+    "english": "When should I look for my invitation in the mail?",
+    "translation": "¿Cuándo debo buscar mi invitación por correo?"
+  },
+  "components.FAQ.entries.whenGetInvitation.answer": {
+    "english": "Starting in March 2020, the U.S. Census Bureau will mail letters to every household in the United States inviting them to respond to the Census survey. Every household should receive a letter requesting that they complete a census form online, by mail, or phone by Census Day on April 1, 2020.",
+    "translation": "A partir de marzo de 2020, la Oficina del Censo de EE. UU. Enviará cartas a todos los hogares de los Estados Unidos invitándolos a responder a la encuesta del Censo. Todos los hogares deben recibir una carta solicitando que completen un formulario del censo en línea, por correo o por teléfono antes del Día del Censo el 1 de abril de 2020."
+  },
+  "components.FAQ.entries.whatTypesOfQuestions.question": {
+    "english": "What types of questions are on the 2020 Census?",
+    "translation": "¿Qué tipos de preguntas se encuentran en el Censo 2020?"
+  },
+  "components.FAQ.entries.whatIsHouseholdRelationshipQuestion.question": {
+    "english": "What is the \"Household Relationship Question\"?",
+    "translation": "¿Qué es la \"Pregunta de relación familiar\"?"
+  },
+  "components.FAQ.entries.whatIsHouseholdRelationshipQuestion.answer": {
+    "english": "For the first time, the 2020 Census offers a way for the person filling out the form to indicate a same-sex relationship with another household member. This change is expected to improve national statistics on same-sex couples.",
+    "translation": "Por primera vez, el Censo 2020 ofrece una manera para que la persona que llena el formulario indique una relación entre personas del mismo sexo con otro miembro del hogar. Se espera que este cambio mejore las estadísticas nacionales sobre parejas del mismo sexo."
+  },
+  "components.FAQ.entries.whoCountsAsHousehold.question": {
+    "english": "Who counts as a \"household?\"",
+    "translation": "¿Quién cuenta como un \"hogar\"?"
+  },
+  "components.FAQ.entries.howLongDoesItTake.question": {
+    "english": "How long does it take to complete the census?",
+    "translation": "¿Cuánto tiempo lleva completar el censo?"
+  },
+  "components.FAQ.entries.howLongDoesItTake.answer": {
+    "english": "The census survey is short and on average takes about 10 minutes or less to complete, depending on the number of people living/sleeping in your home.",
+    "translation": "La encuesta del censo es corta y, en promedio, demora aproximadamente 10 minutos o menos en completarse, dependiendo del número de personas que viven / duermen en su hogar."
+  },
+  "components.FAQ.entries.howCanIComplete.question": {
+    "english": "How can I complete the census?",
+    "translation": "¿Cómo puedo completar el censo?"
+  },
+  "components.FAQ.entries.howCanIComplete.answer": {
+    "english": "There are three ways you can fill out the Census survey: online, by telephone, or via mail. Households can answer the questions on the internet or by phone in English and 12 Non-English languages.",
+    "translation": "Hay tres formas de completar la encuesta del Censo: en línea, por teléfono o por correo. Los hogares pueden responder las preguntas en Internet o por teléfono en inglés y en 12 idiomas que no están en inglés."
+  },
+  "components.FAQ.entries.isFirstTimeAvailableOnline.question": {
+    "english": "Is this the first time the census survey will be available online?",
+    "translation": "¿Es la primera vez que la encuesta del censo estará disponible en línea?"
+  },
+  "components.FAQ.entries.isFirstTimeAvailableOnline.answer": {
+    "english": "Yes! The 2020 Census will be the first Census to be almost entirely digital! The survey will be available in English and 12 Non-English languages.",
+    "translation": "¡Sí! ¡El Censo 2020 será el primer censo en ser casi completamente digital! La encuesta estará disponible en inglés y 12 idiomas que no sean inglés."
+  },
+  "components.FAQ.entries.whenCanFillOut.question": {
+    "english": "When can I go online to fill out the census survey?",
+    "translation": "¿Cuándo puedo conectarme en línea para completar la encuesta del censo?"
+  },
+  "components.FAQ.entries.whenCanFillOut.answer": {
+    "english": "Beginning in mid-March 2020, households will receive an invitation in the mail to participate in the census by visiting the U.S. Census Bureau’s 2020 Census website to fill out the online survey.",
+    "translation": "A partir de mediados de marzo de 2020, los hogares recibirán una invitación por correo para participar en el censo visitando el sitio web del Censo 2020 de la Oficina del Censo de EE. UU. Para completar la encuesta en línea."
+  },
+  "components.FAQ.entries.lostCensusId.question": {
+    "english": "I don’t have or lost my census ID. Can I still complete the census?",
+    "translation": "No tengo ni perdí mi identificación del censo. ¿Puedo completar el censo?"
+  },
+  "components.FAQ.entries.lostCensusId.answer": {
+    "english": "Yes. If you did not receive a census ID code or misplaced it, you can still complete the online census survey by using your mailing address. If you don’t want to respond online, you can call Census Questionnaire Assistance at (###) to complete the survey over the phone.",
+    "translation": "Sí. Si no recibió un código de identificación del censo o lo extravió, aún puede completar la encuesta del censo en línea utilizando su dirección postal. Si no desea responder en línea, puede llamar a Asistencia del cuestionario del censo al (###) para completar la encuesta por teléfono."
+  },
+  "components.FAQ.entries.noAccessToComputer.question": {
+    "english": "What if I don’t have access to a computer?",
+    "translation": "¿Qué sucede si no tengo acceso a una computadora?"
+  },
+  "components.FAQ.entries.noAccessToComputer.answer": {
+    "english": "Households that do not have internet access are encouraged to visit a Census Kiosk to get counted in the 2020 Census. These dedicated computer stations will be available at City library branches, community centers and City Hall. In-person assistance will be available at most locations.",
+    "translation": "Se alienta a los hogares que no tienen acceso a Internet a visitar un quiosco del censo para que se les cuente en el censo de 2020. Estas estaciones de computadoras dedicadas estarán disponibles en las sucursales de la biblioteca de la Ciudad, los centros comunitarios y el Ayuntamiento. La asistencia en persona estará disponible en la mayoría de los lugares."
+  },
+  "components.FAQ.entries.whatHappensIfNoResponse.question": {
+    "english": "What happens if I don’t respond to the Census?",
+    "translation": "¿Qué sucede si no respondo al censo?"
+  },
+  "components.FAQ.entries.whatHappensIfNoResponse.answer": {
+    "english": "If your household fails to respond online or by telephone, the U.S. Census Bureau will mail several reminders to your household and will ultimately mail you a printed questionnaire—in English and Spanish—for you to return by mail.",
+    "translation": "Si su hogar no responde en línea o por teléfono, la Oficina del Censo de EE. UU. Enviará por correo varios recordatorios a su hogar y finalmente le enviará un cuestionario impreso, en inglés y español, para que lo devuelva por correo."
+  },
+  "components.FAQ.entries.whatHappensIfNoResponseAtAll.question": {
+    "english": "What happens if I don’t respond to the census at all?",
+    "translation": "¿Qué sucede si no respondo en absoluto al censo?"
+  },
+  "components.FAQ.entries.whatHappensIfNoResponseAtAll.answer": {
+    "english": "If your household does not respond to the Census online, by phone, or via mail by late April 2020, the U.S. Census Bureau will send a Census worker, known as an enumerator, to your address to help you complete the survey. To avoid a visit from a census worker, complete the census survey on your own.",
+    "translation": "Si su hogar no responde al Censo en línea, por teléfono o por correo a fines de abril de 2020, la Oficina del Censo de EE. UU. Enviará a un trabajador del Censo, conocido como enumerador, a su dirección para ayudarlo a completar la encuesta. Para evitar la visita de un trabajador del censo, complete la encuesta del censo por su cuenta."
+  },
+  "components.FAQ.entries.whatWillCensusWorkerAsk.question": {
+    "english": "What will the Census worker ask me?",
+    "translation": "¿Qué me preguntará el trabajador del censo?"
+  },
+  "components.FAQ.entries.whatWillCensusWorkerAsk.answer": {
+    "english": "The Census worker will ask you all the same survey questions that will appear in the online version of the Census.",
+    "translation": "El trabajador del censo le hará las mismas preguntas de la encuesta que aparecerán en la versión en línea del censo."
+  },
+  "components.FAQ.entries.otherLanguages.question": {
+    "english": "I don’t speak English. Will the Census survey be available in other languages?",
+    "translation": "No hablo ingles ¿La encuesta del censo estará disponible en otros idiomas?"
+  },
+  "components.FAQ.entries.otherLanguages.answer": {
+    "english": "Yes. The online survey is available in English and 12 other languages (Spanish, Chinese, Vietnamese, Korean, Russian, Arabic, Tagalog, Polish, French, Haitian Creole, Portuguese, Japanese); phone assistance will also be available in these languages by calling (####). The paper survey is available in English and Spanish. Print and video language guides will be available in 59 Non-English languages, including American Sign Language, Braille, and large print.",
+    "translation": "Sí. La encuesta en línea está disponible en inglés y otros 12 idiomas (español, chino, vietnamita, coreano, ruso, árabe, tagalo, polaco, francés, criollo haitiano, portugués y japonés); La asistencia telefónica también estará disponible en estos idiomas llamando al (####). La encuesta en papel está disponible en inglés y español. Las guías de idiomas impresas y en video estarán disponibles en 59 idiomas que no sean inglés, incluyendo lenguaje de señas americano, braille y letra grande."
+  },
+  "components.FAQ.entries.isCensusSafe.question": {
+    "english": "Is the Census safe?",
+    "translation": "¿Es seguro el censo?"
+  },
+  "components.FAQ.entries.isCensusSafe.answer": {
+    "english": "Under federal census law, your responses are kept confidential and can only be used by the U.S. Census Bureau to produce statistics.",
+    "translation": "Según la ley del censo federal, sus respuestas se mantienen confidenciales y solo pueden ser utilizadas por la Oficina del Censo de los EE. UU. Para producir estadísticas."
+  },
+  "components.FAQ.entries.canOtherAgenciesAccess.question": {
+    "english": "Can another government agency access my census information?",
+    "translation": "¿Puede otra agencia gubernamental acceder a mi información censal?"
+  },
+  "components.FAQ.entries.canOtherAgenciesAccess.answer": {
+    "english": "No. Title 13 of the U.S. Code requires your information to be kept confidential and prevents your responses from being used against you by any government agency--including law enforcement, the Department of Homeland Security, or US Immigration and Customs Enforcement. All Census Bureau employees take an oath of privacy and are sworn for life to protect the confidentiality of the data. The penalty for unlawful disclosure is a fine of up to $250,000, imprisonment of up to 5 years, or both.",
+    "translation": "No. El Título 13 del Código de EE. UU. Requiere que su información se mantenga confidencial y evita que sus respuestas sean utilizadas en su contra por cualquier agencia gubernamental, incluidas las fuerzas del orden público, el Departamento de Seguridad Nacional o el Servicio de Inmigración y Control de Aduanas de EE. UU. Todos los empleados de la Oficina del Censo hacen un juramento de privacidad y juran de por vida para proteger la confidencialidad de los datos. La multa por divulgación ilegal es una multa de hasta $ 250,000, prisión de hasta 5 años, o ambas."
+  },
+  "components.FAQ.entries.howToIdentifyCensusWorker.question": {
+    "english": "How do I identify an official census worker in person?",
+    "translation": "¿Cómo identifico personalmente a un trabajador del censo oficial?"
+  },
+  "components.FAQ.entries.howToAvoidScams.question": {
+    "english": "How can I avoid scams online?",
+    "translation": "¿Cómo puedo evitar las estafas en línea?"
+  },
+  "components.FAQ.entries.howToReportFraud.question": {
+    "english": "How do I report suspected fraud?",
+    "translation": "¿Cómo denuncio la sospecha de fraude?"
+  },
+  "components.FAQ.entries.howToReportFraud.answer": {
+    "english": "If you suspect fraud, call {phoneNumber} and press option 3 to speak with a local Census Bureau representative. If it is determined that the visitor who came to your door does not work for the Census Bureau, contact the Police Department (phone ##).",
+    "translation": "Si sospecha de fraude, llame a {phoneNumber} y presione la opción 3 para hablar con un representante local de la Oficina del Censo. Si se determina que el visitante que llegó a su puerta no trabaja para la Oficina del Censo, comuníquese con el Departamento de Policía (teléfono ##)."
+  },
+  "email.messages.confirmation.greeting": {
+    "english": "Hi {name}",
+    "translation": "Nombre Hola}"
+  },
+  "email.messages.confirmation.thankYou": {
+    "english": "Thank you for your interest in the 2020 Census effort in San Jose.",
+    "translation": "Gracias por su interés en el esfuerzo del Censo 2020 en San José."
+  },
+  "email.messages.confirmation.usersMessageIntro": {
+    "english": "The following message was sent by you to the City of San Jose Census Office:",
+    "translation": "Usted envió el siguiente mensaje a la Oficina del Censo de la Ciudad de San José:"
+  },
+  "email.messages.confirmation.interestsHeader": {
+    "english": "I have an interest in:",
+    "translation": "Tengo interés en:"
+  },
+  "email.messages.confirmation.commentsHeader": {
+    "english": "Additional comments:",
+    "translation": "Comentarios adicionales:"
+  },
+  "email.messages.confirmation.conclusion": {
+    "english": "Thank you again for your interest. Someone will respond back to you within two business days.",
+    "translation": "Gracias otra vez por su interés. Alguien le responderá dentro de dos días hábiles."
+  },
+  "email.messages.confirmation.signature": {
+    "english": "City of San Jose 2020 Census Office",
+    "translation": "Oficina del Censo de la Ciudad de San José 2020"
+  },
+  "mail.messages.confirmation.subject": {
+    "english": "Thank you for contacting the San Jose Census Department",
+    "translation": "Gracias por contactar al Departamento del Censo de San José."
+  },
+  "components.FAQ.entries.whatTypesOfQuestions.answer": {
+    "english": "The Census survey will ask basic information about each household, such as the total number of people living at your address, homeownership (own or rent), your phone number, and the names, gender, race/ethnicity of each individual living or staying with you. This information will not be shared with the City or any other local, state or federal agency. For more information on what you will be asked on the Census go to the URL below.\n            \n{link}",
+    "translation": "La encuesta del Censo solicitará información básica sobre cada hogar, como el número total de personas que viven en su dirección, la propiedad de la vivienda (propia o alquilada), su número de teléfono y los nombres, género, raza / etnia de cada individuo que vive o se queda con tú. Esta información no se compartirá con la Ciudad ni con ninguna otra agencia local, estatal o federal. Para obtener más información sobre lo que se le pedirá en el Censo, vaya a la URL a continuación.\n            \n{enlazar}"
+  },
+  "components.FAQ.entries.whoCountsAsHousehold.answer": {
+    "english": "A household consists of all the people who occupy a housing unit, both related family members and all the unrelated people, if any, such as lodgers, foster children, wards, or employees who share the housing. For more information on who to count on your Census form go to the URL below.\n          \n{link}",
+    "translation": "Un hogar está formado por todas las personas que ocupan una unidad de vivienda, tanto los miembros de la familia relacionados como todas las personas no relacionadas, si las hay, como inquilinos, hijos adoptivos, barrios o empleados que comparten la vivienda. Para obtener más información sobre con quién contar en su formulario del Censo, vaya a la URL a continuación.\n          \n{enlazar}"
+  },
+  "components.FAQ.entries.howToIdentifyCensusWorker.answer": {
+    "english": "If someone visits your home to collect a response for the 2020 Census, there are steps you can take to verify their identity:\n              \n  First, check to make sure that they have a valid ID badge, with their photograph, a Department of Commerce watermark, and an expiration date.\n  Note that they may be carrying a Census Bureau phone or a laptop, plus a bag with a Census Bureau logo.\n  If you still have questions, call 855-562-2020 and press option 3 to speak with a local Census Bureau representative.\n  \n  Remember that the U.S. Census Bureau will never ask for:\n  \n  - Your Social Security number.\n  - Your bank account or credit card numbers.\n  - Money or donations.\n  \n  In addition, the Census Bureau will not contact you on behalf of a political party.",
+    "translation": "Si alguien visita su hogar para recopilar una respuesta para el Censo 2020, hay pasos que puede seguir para verificar su identidad:\n              \n  Primero, verifique para asegurarse de que tengan una credencial de identificación válida, con su fotografía, una marca de agua del Departamento de Comercio y una fecha de vencimiento.\n  Tenga en cuenta que pueden llevar un teléfono de la Oficina del Censo o una computadora portátil, además de una bolsa con el logotipo de la Oficina del Censo.\n  Si aún tiene preguntas, llame al 855-562-2020 y presione la opción 3 para hablar con un representante local de la Oficina del Censo.\n  \n  Recuerde que la Oficina del Censo de EE. UU. Nunca solicitará:\n  \n  - Su número de seguro social.\n  - Su cuenta bancaria o números de tarjeta de crédito.\n  - Dinero o donaciones.\n  \n  Además, la Oficina del Censo no se comunicará con usted en nombre de un partido político."
+  },
+  "components.FAQ.entries.howToAvoidScams.answer": {
+    "english": "Phishing is the criminal act of trying to get your information by pretending to be an entity that you trust. Phishing emails often direct you to a website that looks real but is fake—and that may be infected with malware.\n\nTo help protect yourself from phishing and other scams, please remember that the U.S. Census Bureau will never ask for:\n\n- Your Social Security number.\n- Your bank account or credit card numbers.\n- Money or donations.\n\nIn addition, the Census Bureau will not contact you on behalf of a political party.",
+    "translation": "El phishing es el acto criminal de tratar de obtener su información fingiendo ser una entidad en la que confía. Los correos electrónicos de phishing a menudo lo dirigen a un sitio web que parece real pero falso, y que puede estar infectado con malware.\n\nPara ayudar a protegerse de la suplantación de identidad (phishing) y otras estafas, recuerde que la Oficina del Censo de EE. UU. Nunca solicitará:\n\n- Su número de seguro social.\n- Su cuenta bancaria o números de tarjeta de crédito.\n- Dinero o donaciones.\n\nAdemás, la Oficina del Censo no se comunicará con usted en nombre de un partido político."
   }
 }

--- a/i18n/translations/translations.vi.json
+++ b/i18n/translations/translations.vi.json
@@ -366,5 +366,233 @@
   "components.SampleCensus.subtitle": {
     "english": "Learn how to answer, how that info is used, and why it's important to answer",
     "translation": "Tìm hiểu cách trả lời, cách sử dụng thông tin đó và tại sao cần trả lời"
+  },
+  "components.FAQ.sections.basics.header": {
+    "english": "Basics",
+    "translation": "Khái niệm cơ bản"
+  },
+  "components.FAQ.sections.about.header": {
+    "english": "About the Survey",
+    "translation": "Về khảo sát"
+  },
+  "components.FAQ.sections.gettingCounted.header": {
+    "english": "Getting Counted",
+    "translation": "Bắt đếm"
+  },
+  "components.FAQ.sections.language.header": {
+    "english": "Language Access",
+    "translation": "Truy cập ngôn ngữ"
+  },
+  "components.FAQ.sections.safety.header": {
+    "english": "Safety and Privacy",
+    "translation": "An toàn và riêng tư"
+  },
+  "components.FAQ.entries.whatIsTheCensus.question": {
+    "english": "What is the census?",
+    "translation": "Điều tra dân số là gì?"
+  },
+  "components.FAQ.entries.whatIsTheCensus.answer": {
+    "english": "The United States Census is a national population count that occurs every ten years. It is mandated by the U.S. Constitution.",
+    "translation": "Tổng điều tra dân số Hoa Kỳ là một số lượng dân số quốc gia xảy ra cứ sau mười năm. Nó được ủy quyền bởi Hiến pháp Hoa Kỳ."
+  },
+  "components.FAQ.entries.whyHaveCensus.question": {
+    "english": "Why do we have a census?",
+    "translation": "Tại sao chúng ta có một cuộc điều tra dân số?"
+  },
+  "components.FAQ.entries.whyHaveCensus.answer": {
+    "english": "The data collected from the Census is used to make sure everyone is equally represented in our political system and that government resources are allocated fairly. The Census data determines how many congressional seats a state receives; how much federal funding will be allocated to local communities for public services and infrastructure needs; and provides a picture of the changing demographics of the country.",
+    "translation": "Dữ liệu được thu thập từ Tổng điều tra được sử dụng để đảm bảo mọi người đều được đại diện như nhau trong hệ thống chính trị của chúng tôi và các nguồn lực của chính phủ được phân bổ công bằng. Dữ liệu điều tra dân số xác định có bao nhiêu ghế quốc hội mà một bang nhận được; bao nhiêu tài trợ liên bang sẽ được phân bổ cho cộng đồng địa phương cho các dịch vụ công cộng và nhu cầu cơ sở hạ tầng; và cung cấp một bức tranh về nhân khẩu học thay đổi của đất nước."
+  },
+  "components.FAQ.entries.whoGetsCounted.question": {
+    "english": "Who gets counted?",
+    "translation": "Ai được tính?"
+  },
+  "components.FAQ.entries.whoGetsCounted.answer": {
+    "english": "Everyone living in the United States must be counted. Make sure you include everyone living and sleeping in your home on your census survey — regardless of age, gender, relationship to you, or citizenship/immigration status.",
+    "translation": "Mọi người sống ở Hoa Kỳ phải được tính. Hãy chắc chắn rằng bạn bao gồm tất cả mọi người sống và ngủ trong nhà của bạn trong cuộc khảo sát điều tra dân số của bạn - bất kể tuổi tác, giới tính, mối quan hệ với bạn, hoặc tình trạng công dân / nhập cư."
+  },
+  "components.FAQ.entries.whenGetInvitation.question": {
+    "english": "When should I look for my invitation in the mail?",
+    "translation": "Khi nào tôi nên tìm lời mời trong thư?"
+  },
+  "components.FAQ.entries.whenGetInvitation.answer": {
+    "english": "Starting in March 2020, the U.S. Census Bureau will mail letters to every household in the United States inviting them to respond to the Census survey. Every household should receive a letter requesting that they complete a census form online, by mail, or phone by Census Day on April 1, 2020.",
+    "translation": "Bắt đầu từ tháng 3 năm 2020, Cục điều tra dân số Hoa Kỳ sẽ gửi thư đến mọi hộ gia đình ở Hoa Kỳ mời họ trả lời khảo sát của Tổng điều tra. Mỗi hộ gia đình sẽ nhận được một lá thư yêu cầu họ hoàn thành mẫu điều tra dân số trực tuyến, qua thư hoặc điện thoại vào Ngày điều tra dân số vào ngày 1 tháng 4 năm 2020."
+  },
+  "components.FAQ.entries.whatTypesOfQuestions.question": {
+    "english": "What types of questions are on the 2020 Census?",
+    "translation": "Những loại câu hỏi nào trong Tổng điều tra dân số năm 2020?"
+  },
+  "components.FAQ.entries.whatIsHouseholdRelationshipQuestion.question": {
+    "english": "What is the \"Household Relationship Question\"?",
+    "translation": "\"Câu hỏi về mối quan hệ gia đình\" là gì?"
+  },
+  "components.FAQ.entries.whatIsHouseholdRelationshipQuestion.answer": {
+    "english": "For the first time, the 2020 Census offers a way for the person filling out the form to indicate a same-sex relationship with another household member. This change is expected to improve national statistics on same-sex couples.",
+    "translation": "Lần đầu tiên, Tổng điều tra dân số năm 2020 đưa ra một cách để người điền vào mẫu đơn biểu thị mối quan hệ đồng giới với một thành viên khác trong gia đình. Sự thay đổi này dự kiến sẽ cải thiện số liệu thống kê quốc gia về các cặp đồng giới."
+  },
+  "components.FAQ.entries.whoCountsAsHousehold.question": {
+    "english": "Who counts as a \"household?\"",
+    "translation": "Ai được coi là \"hộ gia đình?\""
+  },
+  "components.FAQ.entries.howLongDoesItTake.question": {
+    "english": "How long does it take to complete the census?",
+    "translation": "Mất bao lâu để hoàn thành tổng điều tra?"
+  },
+  "components.FAQ.entries.howLongDoesItTake.answer": {
+    "english": "The census survey is short and on average takes about 10 minutes or less to complete, depending on the number of people living/sleeping in your home.",
+    "translation": "Khảo sát điều tra dân số ngắn và trung bình mất khoảng 10 phút hoặc ít hơn để hoàn thành, tùy thuộc vào số người sống / ngủ trong nhà bạn."
+  },
+  "components.FAQ.entries.howCanIComplete.question": {
+    "english": "How can I complete the census?",
+    "translation": "Làm thế nào tôi có thể hoàn thành điều tra dân số?"
+  },
+  "components.FAQ.entries.howCanIComplete.answer": {
+    "english": "There are three ways you can fill out the Census survey: online, by telephone, or via mail. Households can answer the questions on the internet or by phone in English and 12 Non-English languages.",
+    "translation": "Có ba cách bạn có thể điền vào khảo sát Điều tra dân số: trực tuyến, qua điện thoại hoặc qua thư. Các hộ gia đình có thể trả lời các câu hỏi trên internet hoặc qua điện thoại bằng tiếng Anh và 12 ngôn ngữ không phải tiếng Anh."
+  },
+  "components.FAQ.entries.isFirstTimeAvailableOnline.question": {
+    "english": "Is this the first time the census survey will be available online?",
+    "translation": "Đây có phải là lần đầu tiên khảo sát điều tra dân số sẽ có sẵn trực tuyến?"
+  },
+  "components.FAQ.entries.isFirstTimeAvailableOnline.answer": {
+    "english": "Yes! The 2020 Census will be the first Census to be almost entirely digital! The survey will be available in English and 12 Non-English languages.",
+    "translation": "Vâng! Tổng điều tra dân số năm 2020 sẽ là Tổng điều tra đầu tiên gần như hoàn toàn bằng kỹ thuật số! Cuộc khảo sát sẽ có sẵn bằng tiếng Anh và 12 ngôn ngữ không phải tiếng Anh."
+  },
+  "components.FAQ.entries.whenCanFillOut.question": {
+    "english": "When can I go online to fill out the census survey?",
+    "translation": "Khi nào tôi có thể lên mạng để điền vào bản khảo sát điều tra dân số?"
+  },
+  "components.FAQ.entries.whenCanFillOut.answer": {
+    "english": "Beginning in mid-March 2020, households will receive an invitation in the mail to participate in the census by visiting the U.S. Census Bureau’s 2020 Census website to fill out the online survey.",
+    "translation": "Bắt đầu từ giữa tháng 3 năm 2020, các hộ gia đình sẽ nhận được thư mời tham gia vào cuộc điều tra dân số bằng cách truy cập trang web của Tổng điều tra dân số Hoa Kỳ năm 2020 để điền vào bản khảo sát trực tuyến."
+  },
+  "components.FAQ.entries.lostCensusId.question": {
+    "english": "I don’t have or lost my census ID. Can I still complete the census?",
+    "translation": "Tôi không có hoặc mất ID điều tra dân số. Tôi vẫn có thể hoàn thành điều tra dân số chứ?"
+  },
+  "components.FAQ.entries.lostCensusId.answer": {
+    "english": "Yes. If you did not receive a census ID code or misplaced it, you can still complete the online census survey by using your mailing address. If you don’t want to respond online, you can call Census Questionnaire Assistance at (###) to complete the survey over the phone.",
+    "translation": "Vâng. Nếu bạn không nhận được mã ID điều tra dân số hoặc đặt sai mã, bạn vẫn có thể hoàn thành khảo sát điều tra dân số trực tuyến bằng cách sử dụng địa chỉ gửi thư của mình. Nếu bạn không muốn trả lời trực tuyến, bạn có thể gọi Hỗ trợ Câu hỏi điều tra dân số theo số (###) để hoàn thành khảo sát qua điện thoại."
+  },
+  "components.FAQ.entries.noAccessToComputer.question": {
+    "english": "What if I don’t have access to a computer?",
+    "translation": "Nếu tôi không có quyền truy cập vào máy tính thì sao?"
+  },
+  "components.FAQ.entries.noAccessToComputer.answer": {
+    "english": "Households that do not have internet access are encouraged to visit a Census Kiosk to get counted in the 2020 Census. These dedicated computer stations will be available at City library branches, community centers and City Hall. In-person assistance will be available at most locations.",
+    "translation": "Các hộ gia đình không có truy cập internet được khuyến khích truy cập Kiosk điều tra dân số để được tính vào Tổng điều tra dân số năm 2020. Các trạm máy tính chuyên dụng này sẽ có sẵn tại các chi nhánh thư viện Thành phố, trung tâm cộng đồng và Tòa thị chính. Hỗ trợ trực tiếp sẽ có sẵn tại hầu hết các địa điểm."
+  },
+  "components.FAQ.entries.whatHappensIfNoResponse.question": {
+    "english": "What happens if I don’t respond to the Census?",
+    "translation": "Điều gì xảy ra nếu tôi không phản ứng với Tổng điều tra?"
+  },
+  "components.FAQ.entries.whatHappensIfNoResponse.answer": {
+    "english": "If your household fails to respond online or by telephone, the U.S. Census Bureau will mail several reminders to your household and will ultimately mail you a printed questionnaire—in English and Spanish—for you to return by mail.",
+    "translation": "Nếu hộ gia đình của bạn không trả lời trực tuyến hoặc qua điện thoại, Cục điều tra dân số Hoa Kỳ sẽ gửi một số lời nhắc đến hộ gia đình của bạn và cuối cùng sẽ gửi cho bạn một bản câu hỏi in bằng tiếng Anh và tiếng Tây Ban Nha để bạn gửi lại qua thư."
+  },
+  "components.FAQ.entries.whatHappensIfNoResponseAtAll.question": {
+    "english": "What happens if I don’t respond to the census at all?",
+    "translation": "Điều gì xảy ra nếu tôi không phản ứng với điều tra dân số?"
+  },
+  "components.FAQ.entries.whatHappensIfNoResponseAtAll.answer": {
+    "english": "If your household does not respond to the Census online, by phone, or via mail by late April 2020, the U.S. Census Bureau will send a Census worker, known as an enumerator, to your address to help you complete the survey. To avoid a visit from a census worker, complete the census survey on your own.",
+    "translation": "Nếu hộ gia đình của bạn không trả lời Điều tra dân số trực tuyến, qua điện thoại hoặc qua thư vào cuối tháng 4 năm 2020, Cục điều tra dân số Hoa Kỳ sẽ gửi một nhân viên điều tra dân số, được gọi là điều tra viên, đến địa chỉ của bạn để giúp bạn hoàn thành khảo sát. Để tránh chuyến thăm của nhân viên điều tra dân số, hãy tự mình hoàn thành khảo sát điều tra dân số."
+  },
+  "components.FAQ.entries.whatWillCensusWorkerAsk.question": {
+    "english": "What will the Census worker ask me?",
+    "translation": "Nhân viên điều tra dân số sẽ hỏi tôi điều gì?"
+  },
+  "components.FAQ.entries.whatWillCensusWorkerAsk.answer": {
+    "english": "The Census worker will ask you all the same survey questions that will appear in the online version of the Census.",
+    "translation": "Nhân viên điều tra dân số sẽ hỏi bạn tất cả các câu hỏi khảo sát tương tự sẽ xuất hiện trong phiên bản trực tuyến của Tổng điều tra."
+  },
+  "components.FAQ.entries.otherLanguages.question": {
+    "english": "I don’t speak English. Will the Census survey be available in other languages?",
+    "translation": "Tôi không nói tiếng Anh. Khảo sát điều tra dân số sẽ có sẵn trong các ngôn ngữ khác?"
+  },
+  "components.FAQ.entries.otherLanguages.answer": {
+    "english": "Yes. The online survey is available in English and 12 other languages (Spanish, Chinese, Vietnamese, Korean, Russian, Arabic, Tagalog, Polish, French, Haitian Creole, Portuguese, Japanese); phone assistance will also be available in these languages by calling (####). The paper survey is available in English and Spanish. Print and video language guides will be available in 59 Non-English languages, including American Sign Language, Braille, and large print.",
+    "translation": "Vâng. Khảo sát trực tuyến có sẵn bằng tiếng Anh và 12 ngôn ngữ khác (Tây Ban Nha, Trung Quốc, Việt Nam, Hàn Quốc, Nga, Ả Rập, Tagalog, Ba Lan, Pháp, Haiti Creole, Bồ Đào Nha, Nhật Bản); hỗ trợ qua điện thoại cũng sẽ có sẵn bằng các ngôn ngữ này bằng cách gọi (####). Khảo sát giấy có sẵn bằng tiếng Anh và tiếng Tây Ban Nha. Hướng dẫn ngôn ngữ in và video sẽ có sẵn bằng 59 ngôn ngữ không phải tiếng Anh, bao gồm Ngôn ngữ ký hiệu của Mỹ, Chữ nổi và chữ in lớn."
+  },
+  "components.FAQ.entries.isCensusSafe.question": {
+    "english": "Is the Census safe?",
+    "translation": "Điều tra dân số có an toàn không?"
+  },
+  "components.FAQ.entries.isCensusSafe.answer": {
+    "english": "Under federal census law, your responses are kept confidential and can only be used by the U.S. Census Bureau to produce statistics.",
+    "translation": "Theo luật điều tra dân số liên bang, các câu trả lời của bạn được giữ bí mật và chỉ có thể được Cục điều tra dân số Hoa Kỳ sử dụng để đưa ra số liệu thống kê."
+  },
+  "components.FAQ.entries.canOtherAgenciesAccess.question": {
+    "english": "Can another government agency access my census information?",
+    "translation": "Một cơ quan chính phủ khác có thể truy cập thông tin điều tra dân số của tôi?"
+  },
+  "components.FAQ.entries.canOtherAgenciesAccess.answer": {
+    "english": "No. Title 13 of the U.S. Code requires your information to be kept confidential and prevents your responses from being used against you by any government agency--including law enforcement, the Department of Homeland Security, or US Immigration and Customs Enforcement. All Census Bureau employees take an oath of privacy and are sworn for life to protect the confidentiality of the data. The penalty for unlawful disclosure is a fine of up to $250,000, imprisonment of up to 5 years, or both.",
+    "translation": "Tiêu đề 13 của Bộ luật Hoa Kỳ yêu cầu giữ bí mật thông tin của bạn và ngăn chặn các phản hồi của bạn được sử dụng chống lại bạn bởi bất kỳ cơ quan chính phủ nào - bao gồm cơ quan thực thi pháp luật, Bộ An ninh Nội địa, hoặc Cơ quan Thực thi Di trú và Hải quan Hoa Kỳ. Tất cả nhân viên của Cục điều tra dân số đều tuyên thệ về quyền riêng tư và tuyên thệ trọn đời để bảo vệ tính bảo mật của dữ liệu. Hình phạt cho việc tiết lộ bất hợp pháp là phạt tiền lên tới 250.000 đô la, phạt tù tới 5 năm hoặc cả hai."
+  },
+  "components.FAQ.entries.howToIdentifyCensusWorker.question": {
+    "english": "How do I identify an official census worker in person?",
+    "translation": "Làm thế nào để tôi xác định một nhân viên điều tra dân số chính thức trong người?"
+  },
+  "components.FAQ.entries.howToAvoidScams.question": {
+    "english": "How can I avoid scams online?",
+    "translation": "Làm thế nào tôi có thể tránh lừa đảo trực tuyến?"
+  },
+  "components.FAQ.entries.howToReportFraud.question": {
+    "english": "How do I report suspected fraud?",
+    "translation": "Làm thế nào để tôi báo cáo nghi ngờ gian lận?"
+  },
+  "components.FAQ.entries.howToReportFraud.answer": {
+    "english": "If you suspect fraud, call {phoneNumber} and press option 3 to speak with a local Census Bureau representative. If it is determined that the visitor who came to your door does not work for the Census Bureau, contact the Police Department (phone ##).",
+    "translation": "Nếu bạn nghi ngờ có gian lận, hãy gọi {phoneNumber} và nhấn tùy chọn 3 để nói chuyện với đại diện của Cục điều tra dân số địa phương. Nếu xác định rằng khách truy cập đến cửa của bạn không làm việc cho Cục điều tra dân số, hãy liên hệ với Sở cảnh sát (điện thoại ##)."
+  },
+  "email.messages.confirmation.greeting": {
+    "english": "Hi {name}",
+    "translation": "Xin chào tên}"
+  },
+  "email.messages.confirmation.thankYou": {
+    "english": "Thank you for your interest in the 2020 Census effort in San Jose.",
+    "translation": "Cảm ơn bạn đã quan tâm đến nỗ lực Điều tra dân số năm 2020 tại San Jose."
+  },
+  "email.messages.confirmation.usersMessageIntro": {
+    "english": "The following message was sent by you to the City of San Jose Census Office:",
+    "translation": "Tin nhắn sau đây được bạn gửi đến Văn phòng điều tra dân số thành phố San Jose:"
+  },
+  "email.messages.confirmation.interestsHeader": {
+    "english": "I have an interest in:",
+    "translation": "Tôi có hứng thú với:"
+  },
+  "email.messages.confirmation.commentsHeader": {
+    "english": "Additional comments:",
+    "translation": "Ý kiến khác:"
+  },
+  "email.messages.confirmation.conclusion": {
+    "english": "Thank you again for your interest. Someone will respond back to you within two business days.",
+    "translation": "Cảm ơn bạn một lần nữa vì sự quan tâm của bạn. Ai đó sẽ trả lời bạn trong vòng hai ngày làm việc."
+  },
+  "email.messages.confirmation.signature": {
+    "english": "City of San Jose 2020 Census Office",
+    "translation": "Văn phòng điều tra dân số thành phố San Jose 2020"
+  },
+  "mail.messages.confirmation.subject": {
+    "english": "Thank you for contacting the San Jose Census Department",
+    "translation": "Cảm ơn bạn đã liên hệ với Cục điều tra dân số San Jose"
+  },
+  "components.FAQ.entries.whatTypesOfQuestions.answer": {
+    "english": "The Census survey will ask basic information about each household, such as the total number of people living at your address, homeownership (own or rent), your phone number, and the names, gender, race/ethnicity of each individual living or staying with you. This information will not be shared with the City or any other local, state or federal agency. For more information on what you will be asked on the Census go to the URL below.\n            \n{link}",
+    "translation": "Khảo sát điều tra dân số sẽ hỏi thông tin cơ bản về từng hộ gia đình, chẳng hạn như tổng số người sống tại địa chỉ của bạn, quyền sở hữu nhà (sở hữu hoặc thuê), số điện thoại của bạn và tên, giới tính, chủng tộc / sắc tộc của từng cá nhân sống hoặc ở với bạn. Thông tin này sẽ không được chia sẻ với Thành phố hoặc bất kỳ cơ quan địa phương, tiểu bang hoặc liên bang nào khác. Để biết thêm thông tin về những gì bạn sẽ được hỏi trên Điều tra dân số, hãy truy cập URL bên dưới.\n            \n{liên kết}"
+  },
+  "components.FAQ.entries.whoCountsAsHousehold.answer": {
+    "english": "A household consists of all the people who occupy a housing unit, both related family members and all the unrelated people, if any, such as lodgers, foster children, wards, or employees who share the housing. For more information on who to count on your Census form go to the URL below.\n          \n{link}",
+    "translation": "Một hộ gia đình bao gồm tất cả những người chiếm giữ một đơn vị nhà ở, cả các thành viên gia đình có liên quan và tất cả những người không liên quan, nếu có, chẳng hạn như người thuê nhà, trẻ em nuôi dưỡng, phường hoặc nhân viên chia sẻ nhà ở. Để biết thêm thông tin về người sẽ tính vào biểu mẫu Điều tra dân số của bạn, hãy truy cập URL bên dưới.\n          \n{liên kết}"
+  },
+  "components.FAQ.entries.howToIdentifyCensusWorker.answer": {
+    "english": "If someone visits your home to collect a response for the 2020 Census, there are steps you can take to verify their identity:\n              \n  First, check to make sure that they have a valid ID badge, with their photograph, a Department of Commerce watermark, and an expiration date.\n  Note that they may be carrying a Census Bureau phone or a laptop, plus a bag with a Census Bureau logo.\n  If you still have questions, call 855-562-2020 and press option 3 to speak with a local Census Bureau representative.\n  \n  Remember that the U.S. Census Bureau will never ask for:\n  \n  - Your Social Security number.\n  - Your bank account or credit card numbers.\n  - Money or donations.\n  \n  In addition, the Census Bureau will not contact you on behalf of a political party.",
+    "translation": "Nếu ai đó đến thăm nhà bạn để thu thập phản hồi cho Tổng điều tra dân số năm 2020, có những bước bạn có thể thực hiện để xác minh danh tính của họ:\n              \n  Trước tiên, hãy kiểm tra để đảm bảo rằng họ có huy hiệu ID hợp lệ, với ảnh của họ, hình mờ của Bộ Thương mại và ngày hết hạn.\n  Lưu ý rằng họ có thể mang theo điện thoại của Cục điều tra dân số hoặc máy tính xách tay, cộng với một chiếc túi có logo Cục điều tra dân số.\n  Nếu bạn vẫn còn thắc mắc, hãy gọi 855-562-2020 và nhấn tùy chọn 3 để nói chuyện với đại diện Cục điều tra dân số địa phương.\n  \n  Hãy nhớ rằng Cục điều tra dân số Hoa Kỳ sẽ không bao giờ yêu cầu:\n  \n  - Số an sinh xã hội của bạn.\n  - Số tài khoản ngân hàng hoặc số thẻ tín dụng của bạn.\n  - Tiền hoặc quyên góp.\n  \n  Ngoài ra, Cục điều tra dân số sẽ không liên lạc với bạn thay mặt cho một đảng chính trị."
+  },
+  "components.FAQ.entries.howToAvoidScams.answer": {
+    "english": "Phishing is the criminal act of trying to get your information by pretending to be an entity that you trust. Phishing emails often direct you to a website that looks real but is fake—and that may be infected with malware.\n\nTo help protect yourself from phishing and other scams, please remember that the U.S. Census Bureau will never ask for:\n\n- Your Social Security number.\n- Your bank account or credit card numbers.\n- Money or donations.\n\nIn addition, the Census Bureau will not contact you on behalf of a political party.",
+    "translation": "Lừa đảo là hành vi phạm tội cố gắng lấy thông tin của bạn bằng cách giả vờ là một thực thể mà bạn tin tưởng. Các email lừa đảo thường hướng bạn đến một trang web trông thật nhưng là giả mạo và có thể bị nhiễm phần mềm độc hại.\n\nĐể giúp bảo vệ bạn khỏi lừa đảo và các trò gian lận khác, vui lòng nhớ rằng Cục điều tra dân số Hoa Kỳ sẽ không bao giờ yêu cầu:\n\n- Số an sinh xã hội của bạn.\n- Số tài khoản ngân hàng hoặc số thẻ tín dụng của bạn.\n- Tiền hoặc quyên góp.\n\nNgoài ra, Cục điều tra dân số sẽ không liên lạc với bạn thay mặt cho một đảng chính trị."
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1582,6 +1582,14 @@
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
     },
+    "autolinker": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/autolinker/-/autolinker-0.28.1.tgz",
+      "integrity": "sha1-BlK0kYgYefB3XazgzcoyM5QqTkc=",
+      "requires": {
+        "gulp-header": "^1.7.1"
+      }
+    },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -2409,6 +2417,21 @@
         "inherits": "^2.0.3",
         "readable-stream": "^2.2.2",
         "typedarray": "^0.0.6"
+      }
+    },
+    "concat-with-sourcemaps": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/concat-with-sourcemaps/-/concat-with-sourcemaps-1.1.0.tgz",
+      "integrity": "sha512-4gEjHJFT9e+2W/77h/DS5SGUgwDaOwprX8L/gl5+3ixnzkVJJsZWDSelmN3Oilw3LNDZjZV0yqH1hLG3k6nghg==",
+      "requires": {
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
       }
     },
     "configstore": {
@@ -4860,6 +4883,16 @@
       "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
       "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
     },
+    "gulp-header": {
+      "version": "1.8.12",
+      "resolved": "https://registry.npmjs.org/gulp-header/-/gulp-header-1.8.12.tgz",
+      "integrity": "sha512-lh9HLdb53sC7XIZOYzTXM4lFuXElv3EVkSDhsd7DoJBj7hm+Ni7D3qYbb+Rr8DuM8nRanBvkVO9d7askreXGnQ==",
+      "requires": {
+        "concat-with-sourcemaps": "*",
+        "lodash.template": "^4.4.0",
+        "through2": "^2.0.0"
+      }
+    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -6213,6 +6246,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
       "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
     },
+    "lodash._reinterpolate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
+    },
     "lodash.at": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.at/-/lodash.at-4.6.0.tgz",
@@ -6237,6 +6275,23 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.tail/-/lodash.tail-4.1.1.tgz",
       "integrity": "sha1-0jM6NtnncXyK0vfKyv7HwytERmQ="
+    },
+    "lodash.template": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
+      "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
+      "requires": {
+        "lodash._reinterpolate": "^3.0.0",
+        "lodash.templatesettings": "^4.0.0"
+      }
+    },
+    "lodash.templatesettings": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
+      "integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
+      "requires": {
+        "lodash._reinterpolate": "^3.0.0"
+      }
     },
     "log-symbols": {
       "version": "2.2.0",
@@ -7858,6 +7913,14 @@
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
+    "react-remarkable": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/react-remarkable/-/react-remarkable-1.1.3.tgz",
+      "integrity": "sha512-H4kfiT0Q84OzNAcNfWKDMe1Xhm/7jJAIHV5n4mAff2N0nGpPtRN2M7zhLXaTalD5DNGCGKEq1b4XApZ/1QpKbg==",
+      "requires": {
+        "remarkable": "^1.x"
+      }
+    },
     "react-responsive-carousel": {
       "version": "3.1.50",
       "resolved": "https://registry.npmjs.org/react-responsive-carousel/-/react-responsive-carousel-3.1.50.tgz",
@@ -8150,6 +8213,15 @@
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
       "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk="
+    },
+    "remarkable": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/remarkable/-/remarkable-1.7.4.tgz",
+      "integrity": "sha512-e6NKUXgX95whv7IgddywbeN/ItCkWbISmc2DiqHJb0wTrqZIexqdco5b8Z3XZoo/48IdNVKM9ZCvTPJ4F5uvhg==",
+      "requires": {
+        "argparse": "^1.0.10",
+        "autolinker": "~0.28.0"
+      }
     },
     "remove-trailing-separator": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-intl": "^3.4.0",
+    "react-remarkable": "^1.1.3",
     "react-responsive-carousel": "^3.1.50",
     "react-router-dom": "^5.0.0",
     "react-toastify": "^5.3.2",


### PR DESCRIPTION
Fixes #61

Also added a FormattedMarkdownMessage component so that localized strings can accept Markdown syntax for basic styling (currently only used by FAQ page but could be used across the app). 