### PR TITLE
Center the +'s in FAQ headers

### DIFF
--- a/client/components/FAQ.scss
+++ b/client/components/FAQ.scss
@@ -57,6 +57,7 @@
       margin-top:12px;
       display: flex;
       flex-direction: row;
+      align-items: center;
 
 
       &::after {


### PR DESCRIPTION
I noticed during the demo that the + buttons in the FAQ headers were top-aligned instead of vertically centered. This fixes that.