### PR TITLE
Add support for textboxes in Markdown

### DIFF
--- a/client/components/SampleTextbox.js
+++ b/client/components/SampleTextbox.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import './SampleTextbox.scss';
+
+export const SampleTextbox = ({ value }) => {
+  return (
+    <textarea
+      className="c_sample-textbox"
+      value={value}
+      readOnly></textarea>
+  );
+};
+
+SampleTextbox.propTypes = {
+  value: PropTypes.string
+};

--- a/client/components/SampleTextbox.scss
+++ b/client/components/SampleTextbox.scss
@@ -1,0 +1,9 @@
+.c_sample-textbox {
+  resize: none;
+  height: 2em;
+  border: none;
+  border-radius: 3px;
+  padding: .25em;
+  background-color: #2F80ED88;
+  text-align: center;
+}


### PR DESCRIPTION
This adds support for putting textboxes in Markdown content with the syntax

```markdown
This is my [|textbox content|] here.
```